### PR TITLE
Chore(#3): 로컬 테스트용 mvnw 추가 및 자동 스크립트 설정

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,13 @@
+# ============================================================
+# CamPost 로컬 backend 실행용 환경변수 템플릿
+# compose(.env)와 분리해서 사용하세요.
+# cp .env.local.example .env.local
+# ============================================================
+
+# ── Spring Boot 필수 값 (RequiredEnvPostProcessor 대상) ──
+SPRING_DATASOURCE_URL=jdbc:postgresql://localhost:5432/campost
+SPRING_DATASOURCE_USERNAME=campost
+SPRING_DATASOURCE_PASSWORD=<REQUIRED>
+APP_CORS_ALLOWED_ORIGINS=http://localhost:5173,http://localhost:3000
+JWT_SECRET=<REQUIRED>
+JWT_EXPIRY_MS=3600000

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ hs_err_pid*
 replay_pid*
 
 .env
+.env.local
 
 # Build outputs
 target/

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,0 +1,3 @@
+wrapperVersion=3.3.4
+distributionType=only-script
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip

--- a/README.md
+++ b/README.md
@@ -160,6 +160,11 @@ copy .env.example .env
 값이 비어 있거나 `<REQUIRED>` 같은 placeholder 상태면
 백엔드는 시작 단계에서 즉시 실패하도록 구성되어 있습니다.
 
+권장 분리 규칙:
+
+- `.env`: Docker Compose 실행용 (`db` 호스트 사용)
+- `.env.local`: 로컬 `./mvnw spring-boot:run` 실행용 (`localhost` 호스트 사용)
+
 ### 2) Docker Compose 실행
 
 기본 실행 (DB + Backend + Pipeline):
@@ -217,8 +222,65 @@ docker compose --profile frontend up --build -d
 
 Docker 없이 백엔드만 로컬에서 실행할 수도 있습니다.
 
+Maven이 설치되어 있지 않은 팀원을 위해 Maven Wrapper(`mvnw`)를 사용합니다.
+
+### 로컬 실행용 환경변수 준비
+
 ```bash
-mvn spring-boot:run
+cp .env.local.example .env.local
+```
+
+Windows PowerShell/CMD:
+
+```bash
+copy .env.local.example .env.local
+```
+
+DB는 compose로 띄우고, 로컬 실행 전에 `.env.local`을 로드합니다.
+
+```bash
+docker compose up -d db
+set -a
+source .env.local
+set +a
+```
+
+### 빠른 개발 루프 스크립트 (권장)
+
+반복 개발 시 아래 스크립트를 사용하면 매번 명령을 직접 입력하지 않아도 됩니다.
+
+최초 1회 로컬 환경 파일 자동 생성/점검:
+
+```bash
+bash scripts/setup-local.sh
+```
+
+로컬 DB 실행 + `.env.local` 로드 + backend 로컬 실행:
+
+```bash
+bash scripts/local-dev.sh
+```
+
+로컬 검증(테스트/컴파일):
+
+```bash
+bash scripts/check-local.sh
+```
+
+PR 직전 통합 스모크(db+backend+pipeline):
+
+```bash
+bash scripts/compose-smoke.sh
+```
+
+테스트/컴파일 확인:
+
+```bash
+./mvnw test
+```
+
+```bash
+./mvnw spring-boot:run
 ```
 
 이 경우 PostgreSQL이 필요하며, `.env` 대신 시스템 환경변수 또는 `application.yml` 기본값을 사용합니다.

--- a/mvnw
+++ b/mvnw
@@ -1,0 +1,295 @@
+#!/bin/sh
+# ----------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------
+# Apache Maven Wrapper startup batch script, version 3.3.4
+#
+# Optional ENV vars
+# -----------------
+#   JAVA_HOME - location of a JDK home dir, required when download maven via java source
+#   MVNW_REPOURL - repo url base for downloading maven distribution
+#   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+#   MVNW_VERBOSE - true: enable verbose log; debug: trace the mvnw script; others: silence the output
+# ----------------------------------------------------------------------------
+
+set -euf
+[ "${MVNW_VERBOSE-}" != debug ] || set -x
+
+# OS specific support.
+native_path() { printf %s\\n "$1"; }
+case "$(uname)" in
+CYGWIN* | MINGW*)
+  [ -z "${JAVA_HOME-}" ] || JAVA_HOME="$(cygpath --unix "$JAVA_HOME")"
+  native_path() { cygpath --path --windows "$1"; }
+  ;;
+esac
+
+# set JAVACMD and JAVACCMD
+set_java_home() {
+  # For Cygwin and MinGW, ensure paths are in Unix format before anything is touched
+  if [ -n "${JAVA_HOME-}" ]; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ]; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+      JAVACCMD="$JAVA_HOME/jre/sh/javac"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+      JAVACCMD="$JAVA_HOME/bin/javac"
+
+      if [ ! -x "$JAVACMD" ] || [ ! -x "$JAVACCMD" ]; then
+        echo "The JAVA_HOME environment variable is not defined correctly, so mvnw cannot run." >&2
+        echo "JAVA_HOME is set to \"$JAVA_HOME\", but \"\$JAVA_HOME/bin/java\" or \"\$JAVA_HOME/bin/javac\" does not exist." >&2
+        return 1
+      fi
+    fi
+  else
+    JAVACMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v java
+    )" || :
+    JAVACCMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v javac
+    )" || :
+
+    if [ ! -x "${JAVACMD-}" ] || [ ! -x "${JAVACCMD-}" ]; then
+      echo "The java/javac command does not exist in PATH nor is JAVA_HOME set, so mvnw cannot run." >&2
+      return 1
+    fi
+  fi
+}
+
+# hash string like Java String::hashCode
+hash_string() {
+  str="${1:-}" h=0
+  while [ -n "$str" ]; do
+    char="${str%"${str#?}"}"
+    h=$(((h * 31 + $(LC_CTYPE=C printf %d "'$char")) % 4294967296))
+    str="${str#?}"
+  done
+  printf %x\\n $h
+}
+
+verbose() { :; }
+[ "${MVNW_VERBOSE-}" != true ] || verbose() { printf %s\\n "${1-}"; }
+
+die() {
+  printf %s\\n "$1" >&2
+  exit 1
+}
+
+trim() {
+  # MWRAPPER-139:
+  #   Trims trailing and leading whitespace, carriage returns, tabs, and linefeeds.
+  #   Needed for removing poorly interpreted newline sequences when running in more
+  #   exotic environments such as mingw bash on Windows.
+  printf "%s" "${1}" | tr -d '[:space:]'
+}
+
+scriptDir="$(dirname "$0")"
+scriptName="$(basename "$0")"
+
+# parse distributionUrl and optional distributionSha256Sum, requires .mvn/wrapper/maven-wrapper.properties
+while IFS="=" read -r key value; do
+  case "${key-}" in
+  distributionUrl) distributionUrl=$(trim "${value-}") ;;
+  distributionSha256Sum) distributionSha256Sum=$(trim "${value-}") ;;
+  esac
+done <"$scriptDir/.mvn/wrapper/maven-wrapper.properties"
+[ -n "${distributionUrl-}" ] || die "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+
+case "${distributionUrl##*/}" in
+maven-mvnd-*bin.*)
+  MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/
+  case "${PROCESSOR_ARCHITECTURE-}${PROCESSOR_ARCHITEW6432-}:$(uname -a)" in
+  *AMD64:CYGWIN* | *AMD64:MINGW*) distributionPlatform=windows-amd64 ;;
+  :Darwin*x86_64) distributionPlatform=darwin-amd64 ;;
+  :Darwin*arm64) distributionPlatform=darwin-aarch64 ;;
+  :Linux*x86_64*) distributionPlatform=linux-amd64 ;;
+  *)
+    echo "Cannot detect native platform for mvnd on $(uname)-$(uname -m), use pure java version" >&2
+    distributionPlatform=linux-amd64
+    ;;
+  esac
+  distributionUrl="${distributionUrl%-bin.*}-$distributionPlatform.zip"
+  ;;
+maven-mvnd-*) MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/ ;;
+*) MVN_CMD="mvn${scriptName#mvnw}" _MVNW_REPO_PATTERN=/org/apache/maven/ ;;
+esac
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+[ -z "${MVNW_REPOURL-}" ] || distributionUrl="$MVNW_REPOURL$_MVNW_REPO_PATTERN${distributionUrl#*"$_MVNW_REPO_PATTERN"}"
+distributionUrlName="${distributionUrl##*/}"
+distributionUrlNameMain="${distributionUrlName%.*}"
+distributionUrlNameMain="${distributionUrlNameMain%-bin}"
+MAVEN_USER_HOME="${MAVEN_USER_HOME:-${HOME}/.m2}"
+MAVEN_HOME="${MAVEN_USER_HOME}/wrapper/dists/${distributionUrlNameMain-}/$(hash_string "$distributionUrl")"
+
+exec_maven() {
+  unset MVNW_VERBOSE MVNW_USERNAME MVNW_PASSWORD MVNW_REPOURL || :
+  exec "$MAVEN_HOME/bin/$MVN_CMD" "$@" || die "cannot exec $MAVEN_HOME/bin/$MVN_CMD"
+}
+
+if [ -d "$MAVEN_HOME" ]; then
+  verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  exec_maven "$@"
+fi
+
+case "${distributionUrl-}" in
+*?-bin.zip | *?maven-mvnd-?*-?*.zip) ;;
+*) die "distributionUrl is not valid, must match *-bin.zip or maven-mvnd-*.zip, but found '${distributionUrl-}'" ;;
+esac
+
+# prepare tmp dir
+if TMP_DOWNLOAD_DIR="$(mktemp -d)" && [ -d "$TMP_DOWNLOAD_DIR" ]; then
+  clean() { rm -rf -- "$TMP_DOWNLOAD_DIR"; }
+  trap clean HUP INT TERM EXIT
+else
+  die "cannot create temp dir"
+fi
+
+mkdir -p -- "${MAVEN_HOME%/*}"
+
+# Download and Install Apache Maven
+verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+verbose "Downloading from: $distributionUrl"
+verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+# select .zip or .tar.gz
+if ! command -v unzip >/dev/null; then
+  distributionUrl="${distributionUrl%.zip}.tar.gz"
+  distributionUrlName="${distributionUrl##*/}"
+fi
+
+# verbose opt
+__MVNW_QUIET_WGET=--quiet __MVNW_QUIET_CURL=--silent __MVNW_QUIET_UNZIP=-q __MVNW_QUIET_TAR=''
+[ "${MVNW_VERBOSE-}" != true ] || __MVNW_QUIET_WGET='' __MVNW_QUIET_CURL='' __MVNW_QUIET_UNZIP='' __MVNW_QUIET_TAR=v
+
+# normalize http auth
+case "${MVNW_PASSWORD:+has-password}" in
+'') MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+has-password) [ -n "${MVNW_USERNAME-}" ] || MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+esac
+
+if [ -z "${MVNW_USERNAME-}" ] && command -v wget >/dev/null; then
+  verbose "Found wget ... using wget"
+  wget ${__MVNW_QUIET_WGET:+"$__MVNW_QUIET_WGET"} "$distributionUrl" -O "$TMP_DOWNLOAD_DIR/$distributionUrlName" || die "wget: Failed to fetch $distributionUrl"
+elif [ -z "${MVNW_USERNAME-}" ] && command -v curl >/dev/null; then
+  verbose "Found curl ... using curl"
+  curl ${__MVNW_QUIET_CURL:+"$__MVNW_QUIET_CURL"} -f -L -o "$TMP_DOWNLOAD_DIR/$distributionUrlName" "$distributionUrl" || die "curl: Failed to fetch $distributionUrl"
+elif set_java_home; then
+  verbose "Falling back to use Java to download"
+  javaSource="$TMP_DOWNLOAD_DIR/Downloader.java"
+  targetZip="$TMP_DOWNLOAD_DIR/$distributionUrlName"
+  cat >"$javaSource" <<-END
+	public class Downloader extends java.net.Authenticator
+	{
+	  protected java.net.PasswordAuthentication getPasswordAuthentication()
+	  {
+	    return new java.net.PasswordAuthentication( System.getenv( "MVNW_USERNAME" ), System.getenv( "MVNW_PASSWORD" ).toCharArray() );
+	  }
+	  public static void main( String[] args ) throws Exception
+	  {
+	    setDefault( new Downloader() );
+	    java.nio.file.Files.copy( java.net.URI.create( args[0] ).toURL().openStream(), java.nio.file.Paths.get( args[1] ).toAbsolutePath().normalize() );
+	  }
+	}
+	END
+  # For Cygwin/MinGW, switch paths to Windows format before running javac and java
+  verbose " - Compiling Downloader.java ..."
+  "$(native_path "$JAVACCMD")" "$(native_path "$javaSource")" || die "Failed to compile Downloader.java"
+  verbose " - Running Downloader.java ..."
+  "$(native_path "$JAVACMD")" -cp "$(native_path "$TMP_DOWNLOAD_DIR")" Downloader "$distributionUrl" "$(native_path "$targetZip")"
+fi
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+if [ -n "${distributionSha256Sum-}" ]; then
+  distributionSha256Result=false
+  if [ "$MVN_CMD" = mvnd.sh ]; then
+    echo "Checksum validation is not supported for maven-mvnd." >&2
+    echo "Please disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  elif command -v sha256sum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | sha256sum -c - >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  elif command -v shasum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | shasum -a 256 -c >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  else
+    echo "Checksum validation was requested but neither 'sha256sum' or 'shasum' are available." >&2
+    echo "Please install either command, or disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  fi
+  if [ $distributionSha256Result = false ]; then
+    echo "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised." >&2
+    echo "If you updated your Maven version, you need to update the specified distributionSha256Sum property." >&2
+    exit 1
+  fi
+fi
+
+# unzip and move
+if command -v unzip >/dev/null; then
+  unzip ${__MVNW_QUIET_UNZIP:+"$__MVNW_QUIET_UNZIP"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -d "$TMP_DOWNLOAD_DIR" || die "failed to unzip"
+else
+  tar xzf${__MVNW_QUIET_TAR:+"$__MVNW_QUIET_TAR"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -C "$TMP_DOWNLOAD_DIR" || die "failed to untar"
+fi
+
+# Find the actual extracted directory name (handles snapshots where filename != directory name)
+actualDistributionDir=""
+
+# First try the expected directory name (for regular distributions)
+if [ -d "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" ]; then
+  if [ -f "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain/bin/$MVN_CMD" ]; then
+    actualDistributionDir="$distributionUrlNameMain"
+  fi
+fi
+
+# If not found, search for any directory with the Maven executable (for snapshots)
+if [ -z "$actualDistributionDir" ]; then
+  # enable globbing to iterate over items
+  set +f
+  for dir in "$TMP_DOWNLOAD_DIR"/*; do
+    if [ -d "$dir" ]; then
+      if [ -f "$dir/bin/$MVN_CMD" ]; then
+        actualDistributionDir="$(basename "$dir")"
+        break
+      fi
+    fi
+  done
+  set -f
+fi
+
+if [ -z "$actualDistributionDir" ]; then
+  verbose "Contents of $TMP_DOWNLOAD_DIR:"
+  verbose "$(ls -la "$TMP_DOWNLOAD_DIR")"
+  die "Could not find Maven distribution directory in extracted archive"
+fi
+
+verbose "Found extracted Maven distribution directory: $actualDistributionDir"
+printf %s\\n "$distributionUrl" >"$TMP_DOWNLOAD_DIR/$actualDistributionDir/mvnw.url"
+mv -- "$TMP_DOWNLOAD_DIR/$actualDistributionDir" "$MAVEN_HOME" || [ -d "$MAVEN_HOME" ] || die "fail to move MAVEN_HOME"
+
+clean || :
+exec_maven "$@"

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -1,0 +1,189 @@
+<# : batch portion
+@REM ----------------------------------------------------------------------------
+@REM Licensed to the Apache Software Foundation (ASF) under one
+@REM or more contributor license agreements.  See the NOTICE file
+@REM distributed with this work for additional information
+@REM regarding copyright ownership.  The ASF licenses this file
+@REM to you under the Apache License, Version 2.0 (the
+@REM "License"); you may not use this file except in compliance
+@REM with the License.  You may obtain a copy of the License at
+@REM
+@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing,
+@REM software distributed under the License is distributed on an
+@REM "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@REM KIND, either express or implied.  See the License for the
+@REM specific language governing permissions and limitations
+@REM under the License.
+@REM ----------------------------------------------------------------------------
+
+@REM ----------------------------------------------------------------------------
+@REM Apache Maven Wrapper startup batch script, version 3.3.4
+@REM
+@REM Optional ENV vars
+@REM   MVNW_REPOURL - repo url base for downloading maven distribution
+@REM   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+@REM   MVNW_VERBOSE - true: enable verbose log; others: silence the output
+@REM ----------------------------------------------------------------------------
+
+@IF "%__MVNW_ARG0_NAME__%"=="" (SET __MVNW_ARG0_NAME__=%~nx0)
+@SET __MVNW_CMD__=
+@SET __MVNW_ERROR__=
+@SET __MVNW_PSMODULEP_SAVE=%PSModulePath%
+@SET PSModulePath=
+@FOR /F "usebackq tokens=1* delims==" %%A IN (`powershell -noprofile "& {$scriptDir='%~dp0'; $script='%__MVNW_ARG0_NAME__%'; icm -ScriptBlock ([Scriptblock]::Create((Get-Content -Raw '%~f0'))) -NoNewScope}"`) DO @(
+  IF "%%A"=="MVN_CMD" (set __MVNW_CMD__=%%B) ELSE IF "%%B"=="" (echo %%A) ELSE (echo %%A=%%B)
+)
+@SET PSModulePath=%__MVNW_PSMODULEP_SAVE%
+@SET __MVNW_PSMODULEP_SAVE=
+@SET __MVNW_ARG0_NAME__=
+@SET MVNW_USERNAME=
+@SET MVNW_PASSWORD=
+@IF NOT "%__MVNW_CMD__%"=="" ("%__MVNW_CMD__%" %*)
+@echo Cannot start maven from wrapper >&2 && exit /b 1
+@GOTO :EOF
+: end batch / begin powershell #>
+
+$ErrorActionPreference = "Stop"
+if ($env:MVNW_VERBOSE -eq "true") {
+  $VerbosePreference = "Continue"
+}
+
+# calculate distributionUrl, requires .mvn/wrapper/maven-wrapper.properties
+$distributionUrl = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionUrl
+if (!$distributionUrl) {
+  Write-Error "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+}
+
+switch -wildcard -casesensitive ( $($distributionUrl -replace '^.*/','') ) {
+  "maven-mvnd-*" {
+    $USE_MVND = $true
+    $distributionUrl = $distributionUrl -replace '-bin\.[^.]*$',"-windows-amd64.zip"
+    $MVN_CMD = "mvnd.cmd"
+    break
+  }
+  default {
+    $USE_MVND = $false
+    $MVN_CMD = $script -replace '^mvnw','mvn'
+    break
+  }
+}
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+if ($env:MVNW_REPOURL) {
+  $MVNW_REPO_PATTERN = if ($USE_MVND -eq $False) { "/org/apache/maven/" } else { "/maven/mvnd/" }
+  $distributionUrl = "$env:MVNW_REPOURL$MVNW_REPO_PATTERN$($distributionUrl -replace "^.*$MVNW_REPO_PATTERN",'')"
+}
+$distributionUrlName = $distributionUrl -replace '^.*/',''
+$distributionUrlNameMain = $distributionUrlName -replace '\.[^.]*$','' -replace '-bin$',''
+
+$MAVEN_M2_PATH = "$HOME/.m2"
+if ($env:MAVEN_USER_HOME) {
+  $MAVEN_M2_PATH = "$env:MAVEN_USER_HOME"
+}
+
+if (-not (Test-Path -Path $MAVEN_M2_PATH)) {
+    New-Item -Path $MAVEN_M2_PATH -ItemType Directory | Out-Null
+}
+
+$MAVEN_WRAPPER_DISTS = $null
+if ((Get-Item $MAVEN_M2_PATH).Target[0] -eq $null) {
+  $MAVEN_WRAPPER_DISTS = "$MAVEN_M2_PATH/wrapper/dists"
+} else {
+  $MAVEN_WRAPPER_DISTS = (Get-Item $MAVEN_M2_PATH).Target[0] + "/wrapper/dists"
+}
+
+$MAVEN_HOME_PARENT = "$MAVEN_WRAPPER_DISTS/$distributionUrlNameMain"
+$MAVEN_HOME_NAME = ([System.Security.Cryptography.SHA256]::Create().ComputeHash([byte[]][char[]]$distributionUrl) | ForEach-Object {$_.ToString("x2")}) -join ''
+$MAVEN_HOME = "$MAVEN_HOME_PARENT/$MAVEN_HOME_NAME"
+
+if (Test-Path -Path "$MAVEN_HOME" -PathType Container) {
+  Write-Verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"
+  exit $?
+}
+
+if (! $distributionUrlNameMain -or ($distributionUrlName -eq $distributionUrlNameMain)) {
+  Write-Error "distributionUrl is not valid, must end with *-bin.zip, but found $distributionUrl"
+}
+
+# prepare tmp dir
+$TMP_DOWNLOAD_DIR_HOLDER = New-TemporaryFile
+$TMP_DOWNLOAD_DIR = New-Item -Itemtype Directory -Path "$TMP_DOWNLOAD_DIR_HOLDER.dir"
+$TMP_DOWNLOAD_DIR_HOLDER.Delete() | Out-Null
+trap {
+  if ($TMP_DOWNLOAD_DIR.Exists) {
+    try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+    catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+  }
+}
+
+New-Item -Itemtype Directory -Path "$MAVEN_HOME_PARENT" -Force | Out-Null
+
+# Download and Install Apache Maven
+Write-Verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+Write-Verbose "Downloading from: $distributionUrl"
+Write-Verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+$webclient = New-Object System.Net.WebClient
+if ($env:MVNW_USERNAME -and $env:MVNW_PASSWORD) {
+  $webclient.Credentials = New-Object System.Net.NetworkCredential($env:MVNW_USERNAME, $env:MVNW_PASSWORD)
+}
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$webclient.DownloadFile($distributionUrl, "$TMP_DOWNLOAD_DIR/$distributionUrlName") | Out-Null
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+$distributionSha256Sum = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionSha256Sum
+if ($distributionSha256Sum) {
+  if ($USE_MVND) {
+    Write-Error "Checksum validation is not supported for maven-mvnd. `nPlease disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties."
+  }
+  Import-Module $PSHOME\Modules\Microsoft.PowerShell.Utility -Function Get-FileHash
+  if ((Get-FileHash "$TMP_DOWNLOAD_DIR/$distributionUrlName" -Algorithm SHA256).Hash.ToLower() -ne $distributionSha256Sum) {
+    Write-Error "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised. If you updated your Maven version, you need to update the specified distributionSha256Sum property."
+  }
+}
+
+# unzip and move
+Expand-Archive "$TMP_DOWNLOAD_DIR/$distributionUrlName" -DestinationPath "$TMP_DOWNLOAD_DIR" | Out-Null
+
+# Find the actual extracted directory name (handles snapshots where filename != directory name)
+$actualDistributionDir = ""
+
+# First try the expected directory name (for regular distributions)
+$expectedPath = Join-Path "$TMP_DOWNLOAD_DIR" "$distributionUrlNameMain"
+$expectedMvnPath = Join-Path "$expectedPath" "bin/$MVN_CMD"
+if ((Test-Path -Path $expectedPath -PathType Container) -and (Test-Path -Path $expectedMvnPath -PathType Leaf)) {
+  $actualDistributionDir = $distributionUrlNameMain
+}
+
+# If not found, search for any directory with the Maven executable (for snapshots)
+if (!$actualDistributionDir) {
+  Get-ChildItem -Path "$TMP_DOWNLOAD_DIR" -Directory | ForEach-Object {
+    $testPath = Join-Path $_.FullName "bin/$MVN_CMD"
+    if (Test-Path -Path $testPath -PathType Leaf) {
+      $actualDistributionDir = $_.Name
+    }
+  }
+}
+
+if (!$actualDistributionDir) {
+  Write-Error "Could not find Maven distribution directory in extracted archive"
+}
+
+Write-Verbose "Found extracted Maven distribution directory: $actualDistributionDir"
+Rename-Item -Path "$TMP_DOWNLOAD_DIR/$actualDistributionDir" -NewName $MAVEN_HOME_NAME | Out-Null
+try {
+  Move-Item -Path "$TMP_DOWNLOAD_DIR/$MAVEN_HOME_NAME" -Destination $MAVEN_HOME_PARENT | Out-Null
+} catch {
+  if (! (Test-Path -Path "$MAVEN_HOME" -PathType Container)) {
+    Write-Error "fail to move MAVEN_HOME"
+  }
+} finally {
+  try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+  catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+}
+
+Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"

--- a/scripts/check-local.sh
+++ b/scripts/check-local.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+echo "[INFO] Running backend local checks..."
+./mvnw test

--- a/scripts/compose-smoke.sh
+++ b/scripts/compose-smoke.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+echo "[INFO] Running integration smoke (db + backend + pipeline)..."
+docker compose up -d --build db backend pipeline
+docker compose ps
+
+echo "[INFO] Recent backend logs"
+docker compose logs --no-color --tail=80 backend || true
+
+echo "[INFO] Recent pipeline logs"
+docker compose logs --no-color --tail=80 pipeline || true

--- a/scripts/compose-smoke.sh
+++ b/scripts/compose-smoke.sh
@@ -4,6 +4,60 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO_ROOT"
 
+ensure_compose_env_file() {
+	if [[ -f .env ]]; then
+		return
+	fi
+
+	if [[ ! -f .env.example ]]; then
+		echo "[ERROR] .env not found and .env.example is missing."
+		echo "[ERROR] Create .env manually before running integration smoke."
+		exit 1
+	fi
+
+	cp .env.example .env
+	echo "[INFO] Created .env from .env.example"
+}
+
+get_env_value() {
+	local key="$1"
+	grep -E "^${key}=" .env | head -n1 | cut -d '=' -f2- || true
+}
+
+validate_env_keys() {
+	local missing=()
+	local key value
+
+	for key in "$@"; do
+		value="$(get_env_value "$key")"
+		if [[ -z "$value" || "$value" == "<REQUIRED>" ]]; then
+			missing+=("$key")
+		fi
+	done
+
+	if (( ${#missing[@]} > 0 )); then
+		echo "[ERROR] .env is missing required values for integration smoke: ${missing[*]}"
+		echo "[ERROR] Fill .env first (copied from .env.example if needed), then rerun."
+		exit 1
+	fi
+}
+
+ensure_compose_env_file
+validate_env_keys \
+	POSTGRES_DB \
+	POSTGRES_USER \
+	POSTGRES_PASSWORD \
+	SPRING_DATASOURCE_URL \
+	SPRING_DATASOURCE_USERNAME \
+	SPRING_DATASOURCE_PASSWORD \
+	APP_CORS_ALLOWED_ORIGINS \
+	JWT_SECRET \
+	JWT_EXPIRY_MS \
+	CRAWL_INTERVAL_MINUTES \
+	HEADLESS \
+	RAW_STORE_DIR \
+	AI_RESULT_DIR
+
 echo "[INFO] Running integration smoke (db + backend + pipeline)..."
 docker compose up -d --build db backend pipeline
 docker compose ps

--- a/scripts/local-dev.sh
+++ b/scripts/local-dev.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+if [[ ! -f .env.local ]]; then
+  if [[ ! -f .env.local.example ]]; then
+    echo "[ERROR] .env.local not found and .env.local.example is missing."
+    exit 1
+  fi
+
+  cp .env.local.example .env.local
+  echo "[INFO] Created .env.local from .env.local.example"
+fi
+
+if grep -q "<REQUIRED>" .env.local; then
+  echo "[ERROR] .env.local contains <REQUIRED> placeholders."
+  echo "        Fill required values before running backend locally."
+  exit 1
+fi
+
+echo "[INFO] Starting PostgreSQL container (db)..."
+docker compose up -d db
+
+echo "[INFO] Waiting for db health check..."
+for _ in $(seq 1 60); do
+  if docker compose ps db | grep -q "healthy"; then
+    break
+  fi
+  sleep 1
+done
+
+if ! docker compose ps db | grep -q "healthy"; then
+  echo "[ERROR] db is not healthy yet. Check logs with: docker compose logs db"
+  exit 1
+fi
+
+echo "[INFO] Loading .env.local and starting backend locally..."
+set -a
+# shellcheck disable=SC1091
+source .env.local
+set +a
+
+exec ./mvnw spring-boot:run

--- a/scripts/local-dev.sh
+++ b/scripts/local-dev.sh
@@ -4,6 +4,44 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO_ROOT"
 
+ensure_compose_env_file() {
+  if [[ -f .env ]]; then
+    return
+  fi
+
+  if [[ ! -f .env.example ]]; then
+    echo "[ERROR] .env not found and .env.example is missing."
+    echo "[ERROR] Create .env manually before running this script."
+    exit 1
+  fi
+
+  cp .env.example .env
+  echo "[INFO] Created .env from .env.example"
+}
+
+get_env_value() {
+  local key="$1"
+  grep -E "^${key}=" .env | head -n1 | cut -d '=' -f2- || true
+}
+
+validate_env_keys() {
+  local missing=()
+  local key value
+
+  for key in "$@"; do
+    value="$(get_env_value "$key")"
+    if [[ -z "$value" || "$value" == "<REQUIRED>" ]]; then
+      missing+=("$key")
+    fi
+  done
+
+  if (( ${#missing[@]} > 0 )); then
+    echo "[ERROR] .env is missing required values for db startup: ${missing[*]}"
+    echo "[ERROR] Fill .env first (copied from .env.example if needed), then rerun."
+    exit 1
+  fi
+}
+
 if [[ ! -f .env.local ]]; then
   if [[ ! -f .env.local.example ]]; then
     echo "[ERROR] .env.local not found and .env.local.example is missing."
@@ -19,6 +57,9 @@ if grep -q "<REQUIRED>" .env.local; then
   echo "        Fill required values before running backend locally."
   exit 1
 fi
+
+ensure_compose_env_file
+validate_env_keys POSTGRES_DB POSTGRES_USER POSTGRES_PASSWORD
 
 echo "[INFO] Starting PostgreSQL container (db)..."
 docker compose up -d db

--- a/scripts/setup-local.sh
+++ b/scripts/setup-local.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+if [[ ! -f .env.local ]]; then
+  if [[ ! -f .env.local.example ]]; then
+    echo "[ERROR] .env.local.example not found."
+    exit 1
+  fi
+
+  cp .env.local.example .env.local
+  echo "[INFO] Created .env.local from .env.local.example"
+  echo "[INFO] Fill required values in .env.local before running backend."
+else
+  echo "[INFO] .env.local already exists."
+fi
+
+if grep -q "<REQUIRED>" .env.local; then
+  echo "[WARN] .env.local still has <REQUIRED> placeholders."
+  echo "[WARN] Please edit .env.local before local backend run."
+fi
+
+echo "[INFO] Local setup check complete."


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #3 

## 🏷️ PR 타입

- [ ] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)
- [x] ⚙️ 프로젝트 초기 설정 (Chore)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🚨 PR 복구 (Revert)

## 📝 작업 내용

- mvnw 추가
- scripts/ 폴더 아래에 shell 스크립트 추가

### setup.local.sh
- 최초 1회 로컬 준비용
- .env.local 이 없으면 .env.local.example 에서 자동 생성

### local-dev.sh
- 실개발 실행용
- .env.local.example 이 없으면 자동 생성하고, <REQUIRED>가 남아 있으면 즉시 실패
- docker compose로 db 컨테이너를 올리고 health 체크 완료까지 기다립니다.
- .env,local 을 로드해서 ./mvnw spring-boot:run을 실행합니다.
- 서버가 켜진 뒤 터미널을 점유하는 것이 정상 동작입니다.

### check-local.sh
- 로컬 빠른 검증용입니다.
- ./mvnw test를 실행해 컴파일/테스트 이상 유무를 확인합니다.
- BUILD SUCCESS면 통과

### compose-smoke.sh
- PR 직전 통합 스모크용입니다.
- db + backend + pipeline을 compose로 빌드/실행하고 상태/최근 로그를 확인합니다.
- 개별 로컬 실행이 아니라 “통합 환경에서 문제 없는지” 보는 용도입니다.

## 첫 pull 이후 권장 순서

### 1. 저장소 최신화
- git pull origin dev

### 2. backend 폴더 이동
- cd CamPost-backend

### 3. 로컬 환경 파일 자동 준비
- bash scripts/setup-local.sh

### 4. 필수값 입력
- .env.local 열어서 <REQUIRED> 값 채우기
- 최소: DB 비밀번호, JWT_SECRET 등

### 5. 빠른 체크
- bash scripts/check-local.sh

### 6. 로컬 서버 실행
- bash scripts/local-dev.sh
- 실행 후 http://localhost:8080/actuator/health 확인

### 7. 작업 마무리 전 통합 확인
- bash scripts/compose-smoke.sh
- 이 단계는 보통 PR 올리기 전 1회 수행

## 📸 스크린샷
<img width="852" height="482" alt="image" src="https://github.com/user-attachments/assets/f61d00f5-b0da-4f3f-9973-c5aa286dcfd1" />


## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다.
- [x] 코드 스타일 가이드를 준수했습니다.
- [x] 셀프 리뷰를 완료했습니다.
- [x] 테스트를 작성하고 모두 통과했습니다.
- [ ] 문서를 업데이트했습니다. (필요한 경우)

## 📎 기타 참고사항

### 1순위 이유는 개발 속도와 안정성
- 백엔드는 로컬에서 바로 실행해야 디버깅이 가장 빠릅니다.
- DB는 로컬 설치 대신 도커로 고정 버전(PostgreSQL 16)으로 띄우면 팀원마다 환경 차이가 줄어듭니다.
- 그래서 백엔드 로컬 + DB만 도커 조합이 가장 가벼운 개발 루프입니다.

### 2순위 이유는 실행 모드 분리
- 로컬 백엔드는 localhost DB로 붙고,
- 풀 compose 모드에서는 서비스 이름(db)로 붙습니다.
- 이걸 분리하면 UnknownHost 같은 모드 혼선이 줄어듭니다.

### pipeline 공유와의 관계
- backend와 pipeline이 같은 DB 스키마/데이터를 쓰기 때문에 DB는 공통 기준점 역할을 합니다.
다만 로컬 백엔드 개발 단계에서는 pipeline까지 항상 띄울 필요가 없어서 DB만 먼저 띄우는 겁니다.

### 정리하면:
- 평소 개발: DB만 도커 + 백엔드 로컬
- 통합 확인(배포 전/PR 전): DB + backend + pipeline 전체 compose 실행


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 로컬 개발용 헬퍼 스크립트 추가 (setup-local, local-dev, check-local, compose-smoke)
  * Maven Wrapper 추가 (mvnw, mvnw.cmd, .mvn/wrapper)로 일관된 빌드 실행 보장

* **문서**
  * README에 로컬 실행 가이드 확장 및 .env vs .env.local 분리 설명 추가

* **기타**
  * 로컬 환경 템플릿(.env.local.example) 추가 및 .env.local git 무시 규칙 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->