### PR TITLE
feat(#9): 응답 스키마 고정

### DIFF
--- a/src/main/java/com/campost/backend/domain/post/notice/dto/NoticeDetailDto.java
+++ b/src/main/java/com/campost/backend/domain/post/notice/dto/NoticeDetailDto.java
@@ -12,7 +12,13 @@ import java.time.OffsetDateTime;
         "id",
         "articleId",
         "title",
+        "author",
+        "category",
         "date",
+        "views",
+        "deadline",
+        "target",
+        "applyMethod",
         "bodyText",
         "sourceUrl",
         "publishedAt",
@@ -25,8 +31,20 @@ public record NoticeDetailDto(
         String articleId,
         @JsonProperty("title")
         String title,
+        @JsonProperty("author")
+        String author,
+        @JsonProperty("category")
+        String category,
         @JsonProperty("date")
         LocalDate date,
+        @JsonProperty("views")
+        Integer views,
+        @JsonProperty("deadline")
+        LocalDate deadline,
+        @JsonProperty("target")
+        String target,
+        @JsonProperty("applyMethod")
+        String applyMethod,
         @JsonProperty("bodyText")
         String bodyText,
         @JsonProperty("sourceUrl")

--- a/src/main/java/com/campost/backend/domain/post/notice/dto/NoticeDetailDto.java
+++ b/src/main/java/com/campost/backend/domain/post/notice/dto/NoticeDetailDto.java
@@ -1,16 +1,39 @@
 package com.campost.backend.domain.post.notice.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 
+@JsonInclude(JsonInclude.Include.ALWAYS)
+@JsonPropertyOrder({
+        "id",
+        "articleId",
+        "title",
+        "date",
+        "bodyText",
+        "sourceUrl",
+        "publishedAt",
+        "createdAt"
+})
 public record NoticeDetailDto(
+        @JsonProperty("id")
         long id,
+        @JsonProperty("articleId")
         String articleId,
+        @JsonProperty("title")
         String title,
+        @JsonProperty("date")
         LocalDate date,
+        @JsonProperty("bodyText")
         String bodyText,
+        @JsonProperty("sourceUrl")
         String sourceUrl,
+        @JsonProperty("publishedAt")
         OffsetDateTime publishedAt,
+        @JsonProperty("createdAt")
         OffsetDateTime createdAt
 ) {
 }

--- a/src/main/java/com/campost/backend/domain/post/notice/dto/NoticeDto.java
+++ b/src/main/java/com/campost/backend/domain/post/notice/dto/NoticeDto.java
@@ -1,21 +1,54 @@
 package com.campost.backend.domain.post.notice.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 
+@JsonInclude(JsonInclude.Include.ALWAYS)
+@JsonPropertyOrder({
+        "id",
+        "articleId",
+        "title",
+        "author",
+        "category",
+        "date",
+        "views",
+        "sourceUrl",
+        "deadline",
+        "target",
+        "applyMethod",
+        "publishedAt",
+        "createdAt"
+})
 public record NoticeDto(
+        @JsonProperty("id")
         long id,
+        @JsonProperty("articleId")
         String articleId,
+        @JsonProperty("title")
         String title,
+        @JsonProperty("author")
         String author,
+        @JsonProperty("category")
         String category,
+        @JsonProperty("date")
         LocalDate date,
+        @JsonProperty("views")
         Integer views,
+        @JsonProperty("sourceUrl")
         String sourceUrl,
+        @JsonProperty("deadline")
         LocalDate deadline,
+        @JsonProperty("target")
         String target,
+        @JsonProperty("applyMethod")
         String applyMethod,
+        @JsonProperty("publishedAt")
         OffsetDateTime publishedAt,
+        @JsonProperty("createdAt")
         OffsetDateTime createdAt
 ) {
 }

--- a/src/main/java/com/campost/backend/domain/post/notice/repository/NoticeQueryRepository.java
+++ b/src/main/java/com/campost/backend/domain/post/notice/repository/NoticeQueryRepository.java
@@ -46,25 +46,32 @@ public class NoticeQueryRepository {
                 .list();
     }
 
-            public Optional<NoticeDetailDto> findNoticeDetailById(long noticeId) {
-            String sql = """
-                SELECT id, article_id, title, date, body_text, source_url, published_at, created_at
+    public Optional<NoticeDetailDto> findNoticeDetailById(long noticeId) {
+        String sql = """
+                SELECT id, article_id, title, author, category, date, views,
+                       deadline, target, apply_method, body_text, source_url, published_at, created_at
                 FROM notices
                 WHERE id = :noticeId
                 """;
 
-            return jdbcClient.sql(sql)
+        return jdbcClient.sql(sql)
                 .param("noticeId", noticeId)
                 .query((rs, rowNum) -> new NoticeDetailDto(
-                    rs.getLong("id"),
-                    rs.getString("article_id"),
-                    rs.getString("title"),
-                    rs.getObject("date", java.time.LocalDate.class),
-                    rs.getString("body_text"),
-                    rs.getString("source_url"),
-                    rs.getObject("published_at", java.time.OffsetDateTime.class),
-                    rs.getObject("created_at", java.time.OffsetDateTime.class)
+                        rs.getLong("id"),
+                        rs.getString("article_id"),
+                        rs.getString("title"),
+                        rs.getString("author"),
+                        rs.getString("category"),
+                        rs.getObject("date", java.time.LocalDate.class),
+                        rs.getObject("views", Integer.class),
+                        rs.getObject("deadline", java.time.LocalDate.class),
+                        rs.getString("target"),
+                        rs.getString("apply_method"),
+                        rs.getString("body_text"),
+                        rs.getString("source_url"),
+                        rs.getObject("published_at", java.time.OffsetDateTime.class),
+                        rs.getObject("created_at", java.time.OffsetDateTime.class)
                 ))
                 .optional();
-            }
+    }
 }

--- a/src/main/java/com/campost/backend/global/api/ApiResponse.java
+++ b/src/main/java/com/campost/backend/global/api/ApiResponse.java
@@ -1,9 +1,19 @@
 package com.campost.backend.global.api;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+@JsonInclude(JsonInclude.Include.ALWAYS)
+@JsonPropertyOrder({"isSuccess", "code", "message", "result"})
 public record ApiResponse<T>(
+    @JsonProperty("isSuccess")
         boolean isSuccess,
+    @JsonProperty("code")
         String code,
+    @JsonProperty("message")
         String message,
+    @JsonProperty("result")
         T result
 ) {
     public static <T> ApiResponse<T> ok(T result) {

--- a/src/main/java/com/campost/backend/global/api/ErrorResponse.java
+++ b/src/main/java/com/campost/backend/global/api/ErrorResponse.java
@@ -1,8 +1,17 @@
 package com.campost.backend.global.api;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+@JsonInclude(JsonInclude.Include.ALWAYS)
+@JsonPropertyOrder({"isSuccess", "code", "message"})
 public record ErrorResponse(
+    @JsonProperty("isSuccess")
         boolean isSuccess,
+    @JsonProperty("code")
         String code,
+    @JsonProperty("message")
         String message
 ) {
     public static ErrorResponse of(ApiCode code) {


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #9 

## 🏷️ PR 타입

- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)
- [ ] ⚙️ 프로젝트 초기 설정 (Chore)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🚨 PR 복구 (Revert)

## 📝 작업 내용

- 적용한 변경

1. 공통 성공 응답 고정
- ApiResponse.java
- 적용:
  - `isSuccess`, `code`, `message`, `result` 키를 `@JsonProperty`로 명시
  - 필드 순서를 `@JsonPropertyOrder`로 고정
  - `@JsonInclude(ALWAYS)`로 null이어도 키 유지

2. 공통 에러 응답 고정
- ErrorResponse.java
- 적용:
  - `isSuccess`, `code`, `message` 키 명시
  - 필드 순서 고정
  - null 포함 정책 고정

3. 공지 목록 DTO 스키마 고정
- NoticeDto.java
- 적용:
  - 모든 필드에 `@JsonProperty` 명시
  - 응답 필드 순서 고정
  - null 포함 정책 고정

4. 공지 상세 DTO 스키마 고정
- NoticeDetailDto.java
- 적용:
  - 모든 필드에 `@JsonProperty` 명시
  - 응답 필드 순서 고정
  - null 포함 정책 고정

## 📸 스크린샷

- 테스트 결과를 스크린샷으로 첨부해주세요.

## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다.
- [x] 코드 스타일 가이드를 준수했습니다.
- [x] 셀프 리뷰를 완료했습니다.
- [x] 테스트를 작성하고 모두 통과했습니다.
- [ ] 문서를 업데이트했습니다. (필요한 경우)

## 📎 기타 참고사항

- 논의가 필요한 부분, 리뷰 시 유의사항 등을 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * API 응답의 필드 순서를 명확하게 정렬하여 응답 일관성을 향상시켰습니다.
  * 모든 데이터 응답에서 필드 포함 규칙을 통일하여 API 예측 가능성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->