### PR TITLE
Feat(#20): 회원가입 요청 DTO 및 응답 형식 정의

### DIFF
--- a/src/main/java/com/campost/backend/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/campost/backend/domain/auth/controller/AuthController.java
@@ -1,0 +1,54 @@
+package com.campost.backend.domain.auth.controller;
+
+import com.campost.backend.domain.auth.dto.SignupRequest;
+import com.campost.backend.domain.auth.dto.SignupResponse;
+import com.campost.backend.global.api.ApiCode;
+import com.campost.backend.global.api.ApiResponse;
+import com.campost.backend.global.api.ErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Auth", description = "인증 API")
+@RestController
+@RequestMapping("/api/v1/auth")
+public class AuthController {
+
+    @Operation(
+            summary = "회원가입",
+            description = "아이디, 이메일, 비밀번호, 닉네임을 검증하고 회원가입 응답 형식을 반환합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "201",
+                    description = "회원가입 요청 형식 검증 성공"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "입력값 검증 실패",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "500",
+                    description = "서버 내부 오류",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+    @PostMapping("/signup")
+    public ResponseEntity<ApiResponse<SignupResponse>> signup(
+            @Valid @RequestBody SignupRequest request
+    ) {
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.ok(ApiCode.AUTH201, SignupResponse.from(request)));
+    }
+}

--- a/src/main/java/com/campost/backend/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/campost/backend/domain/auth/controller/AuthController.java
@@ -25,7 +25,7 @@ public class AuthController {
 
     @Operation(
             summary = "회원가입",
-            description = "아이디, 이메일, 비밀번호, 닉네임을 검증하고 회원가입 응답 형식을 반환합니다."
+            description = "아이디, 이메일, 비밀번호를 검증하고 회원가입 응답 형식을 반환합니다."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(

--- a/src/main/java/com/campost/backend/domain/auth/dto/SignupRequest.java
+++ b/src/main/java/com/campost/backend/domain/auth/dto/SignupRequest.java
@@ -1,0 +1,38 @@
+package com.campost.backend.domain.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "회원가입 요청")
+public record SignupRequest(
+        @Schema(description = "아이디", example = "campost123")
+        @NotBlank(message = "아이디를 입력해주세요.")
+        @Pattern(
+                regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{6,20}$",
+                message = "아이디는 영문과 숫자를 모두 포함해 6~20자로 입력해주세요."
+        )
+        String username,
+
+        @Schema(description = "이메일", example = "campost@example.com")
+        @NotBlank(message = "이메일을 입력해주세요.")
+        @Email(message = "올바른 이메일 형식으로 입력해주세요.")
+        @Size(max = 255, message = "이메일은 255자 이하로 입력해주세요.")
+        String email,
+
+        @Schema(description = "비밀번호", example = "password123")
+        @NotBlank(message = "비밀번호를 입력해주세요.")
+        @Pattern(
+                regexp = "^(?=.*[A-Za-z])(?=.*\\d).{8,}$",
+                message = "비밀번호는 영문과 숫자를 모두 포함해 8자 이상으로 입력해주세요."
+        )
+        String password,
+
+        @Schema(description = "닉네임", example = "캠포스트")
+        @NotBlank(message = "닉네임을 입력해주세요.")
+        @Size(min = 2, max = 30, message = "닉네임은 2~30자로 입력해주세요.")
+        String nickname
+) {
+}

--- a/src/main/java/com/campost/backend/domain/auth/dto/SignupRequest.java
+++ b/src/main/java/com/campost/backend/domain/auth/dto/SignupRequest.java
@@ -28,11 +28,6 @@ public record SignupRequest(
                 regexp = "^(?=.*[A-Za-z])(?=.*\\d).{8,}$",
                 message = "비밀번호는 영문과 숫자를 모두 포함해 8자 이상으로 입력해주세요."
         )
-        String password,
-
-        @Schema(description = "닉네임", example = "캠포스트")
-        @NotBlank(message = "닉네임을 입력해주세요.")
-        @Size(min = 2, max = 30, message = "닉네임은 2~30자로 입력해주세요.")
-        String nickname
+        String password
 ) {
 }

--- a/src/main/java/com/campost/backend/domain/auth/dto/SignupResponse.java
+++ b/src/main/java/com/campost/backend/domain/auth/dto/SignupResponse.java
@@ -1,0 +1,23 @@
+package com.campost.backend.domain.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "회원가입 응답")
+public record SignupResponse(
+        @Schema(description = "아이디", example = "campost123")
+        String username,
+
+        @Schema(description = "이메일", example = "campost@example.com")
+        String email,
+
+        @Schema(description = "닉네임", example = "캠포스트")
+        String nickname
+) {
+    public static SignupResponse from(SignupRequest request) {
+        return new SignupResponse(
+                request.username(),
+                request.email(),
+                request.nickname()
+        );
+    }
+}

--- a/src/main/java/com/campost/backend/domain/auth/dto/SignupResponse.java
+++ b/src/main/java/com/campost/backend/domain/auth/dto/SignupResponse.java
@@ -8,16 +8,12 @@ public record SignupResponse(
         String username,
 
         @Schema(description = "이메일", example = "campost@example.com")
-        String email,
-
-        @Schema(description = "닉네임", example = "캠포스트")
-        String nickname
+        String email
 ) {
     public static SignupResponse from(SignupRequest request) {
         return new SignupResponse(
                 request.username(),
-                request.email(),
-                request.nickname()
+                request.email()
         );
     }
 }

--- a/src/main/java/com/campost/backend/global/api/ApiCode.java
+++ b/src/main/java/com/campost/backend/global/api/ApiCode.java
@@ -4,6 +4,7 @@ import org.springframework.http.HttpStatus;
 
 public enum ApiCode {
     COMMON200(HttpStatus.OK, "COMMON200", "요청이 성공했습니다."),
+    AUTH201(HttpStatus.CREATED, "AUTH201", "회원가입 요청 형식 검증에 성공했습니다."),
     COMMON400(HttpStatus.BAD_REQUEST, "COMMON400", "잘못된 요청입니다."),
     TOKEN401(HttpStatus.UNAUTHORIZED, "TOKEN401", "액세스 토큰이 만료되었습니다."),
     TOKEN402(HttpStatus.UNAUTHORIZED, "TOKEN402", "유효하지 않은 토큰입니다."),

--- a/src/test/java/com/campost/backend/domain/auth/dto/SignupRequestValidationTest.java
+++ b/src/test/java/com/campost/backend/domain/auth/dto/SignupRequestValidationTest.java
@@ -15,8 +15,7 @@ class SignupRequestValidationTest {
         SignupRequest request = new SignupRequest(
                 "campost123",
                 "campost@example.com",
-                "password123",
-                "캠포스트"
+                "password123"
         );
 
         assertThat(validator.validate(request)).isEmpty();
@@ -27,13 +26,12 @@ class SignupRequestValidationTest {
         SignupRequest request = new SignupRequest(
                 "",
                 "",
-                "",
                 ""
         );
 
         assertThat(validator.validate(request))
                 .extracting(violation -> violation.getPropertyPath().toString())
-                .contains("username", "email", "password", "nickname");
+                .contains("username", "email", "password");
     }
 
     @Test
@@ -41,8 +39,7 @@ class SignupRequestValidationTest {
         SignupRequest request = new SignupRequest(
                 "campost123",
                 "invalid-email",
-                "password123",
-                "캠포스트"
+                "password123"
         );
 
         assertThat(validator.validate(request))
@@ -54,8 +51,7 @@ class SignupRequestValidationTest {
         SignupRequest request = new SignupRequest(
                 "campost123",
                 "campost@example.com",
-                "password",
-                "캠포스트"
+                "password"
         );
 
         assertThat(validator.validate(request))
@@ -67,8 +63,7 @@ class SignupRequestValidationTest {
         SignupRequest request = new SignupRequest(
                 "campost123",
                 "campost@example.com",
-                "abc123",
-                "캠포스트"
+                "abc123"
         );
 
         assertThat(validator.validate(request))

--- a/src/test/java/com/campost/backend/domain/auth/dto/SignupRequestValidationTest.java
+++ b/src/test/java/com/campost/backend/domain/auth/dto/SignupRequestValidationTest.java
@@ -1,0 +1,77 @@
+package com.campost.backend.domain.auth.dto;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SignupRequestValidationTest {
+
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+    @Test
+    void validSignupRequestPassesValidation() {
+        SignupRequest request = new SignupRequest(
+                "campost123",
+                "campost@example.com",
+                "password123",
+                "캠포스트"
+        );
+
+        assertThat(validator.validate(request)).isEmpty();
+    }
+
+    @Test
+    void blankRequiredFieldsFailValidation() {
+        SignupRequest request = new SignupRequest(
+                "",
+                "",
+                "",
+                ""
+        );
+
+        assertThat(validator.validate(request))
+                .extracting(violation -> violation.getPropertyPath().toString())
+                .contains("username", "email", "password", "nickname");
+    }
+
+    @Test
+    void invalidEmailFormatFailsValidation() {
+        SignupRequest request = new SignupRequest(
+                "campost123",
+                "invalid-email",
+                "password123",
+                "캠포스트"
+        );
+
+        assertThat(validator.validate(request))
+                .anyMatch(violation -> violation.getPropertyPath().toString().equals("email"));
+    }
+
+    @Test
+    void passwordWithoutLetterAndNumberFailsValidation() {
+        SignupRequest request = new SignupRequest(
+                "campost123",
+                "campost@example.com",
+                "password",
+                "캠포스트"
+        );
+
+        assertThat(validator.validate(request))
+                .anyMatch(violation -> violation.getPropertyPath().toString().equals("password"));
+    }
+
+    @Test
+    void shortPasswordFailsValidation() {
+        SignupRequest request = new SignupRequest(
+                "campost123",
+                "campost@example.com",
+                "abc123",
+                "캠포스트"
+        );
+
+        assertThat(validator.validate(request))
+                .anyMatch(violation -> violation.getPropertyPath().toString().equals("password"));
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #20 

## 🏷️ PR 타입

- [ ] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)
- [ ] ⚙️ 프로젝트 초기 설정 (Chore)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🚨 PR 복구 (Revert)

## 📝 작업 내용


-SignupRequest DTO 추가
-username, email, password, nickname
-필수값, 이메일 형식, 아이디 규칙, 비밀번호 규칙, 닉네임 길이 validation 포함
-SignupResponse DTO 추가
-기존 공통 응답 포맷 ApiResponse / ErrorResponse를 회원가입 응답에 사용
-AUTH201 응답 코드 추가
-Swagger에 노출되도록 POST /api/v1/auth/signup 컨트롤러 추가
-DTO validation 테스트 추가

추가된 주요 파일:

src/main/java/com/campost/backend/domain/auth/dto/SignupRequest.java
src/main/java/com/campost/backend/domain/auth/dto/SignupResponse.java
src/main/java/com/campost/backend/domain/auth/controller/AuthController.java
src/test/java/com/campost/backend/domain/auth/dto/SignupRequestValidationTest.java

## 📸 스크린샷

- 

## ✅ 체크리스트

- [ ] 코드 리뷰를 받을 준비가 완료되었습니다.
- [ ] 코드 스타일 가이드를 준수했습니다.
- [ ] 셀프 리뷰를 완료했습니다.
- [ ] 테스트를 작성하고 모두 통과했습니다.
- [ ] 문서를 업데이트했습니다. (필요한 경우)

## 📎 기타 참고사항

- 논의가 필요한 부분, 리뷰 시 유의사항 등을 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 회원가입 기능을 추가했습니다. 사용자는 사용자명, 이메일, 비밀번호를 통해 새로운 계정을 생성할 수 있습니다.
  * 사용자명은 6-20자의 영문과 숫자를 포함해야 하며, 이메일은 유효한 형식이어야 하고, 비밀번호는 최소 8자 이상으로 영문과 숫자를 모두 포함해야 합니다.

* **테스트**
  * 회원가입 요청 입력값 유효성 검사 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->