### PR TITLE
Feat(#22): 사용자 기본 정보 저장 로직 구현

### DIFF
--- a/src/main/java/com/campost/backend/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/campost/backend/domain/auth/controller/AuthController.java
@@ -2,6 +2,7 @@ package com.campost.backend.domain.auth.controller;
 
 import com.campost.backend.domain.auth.dto.SignupRequest;
 import com.campost.backend.domain.auth.dto.SignupResponse;
+import com.campost.backend.domain.auth.service.SignupUserService;
 import com.campost.backend.global.api.ApiCode;
 import com.campost.backend.global.api.ApiResponse;
 import com.campost.backend.global.api.ErrorResponse;
@@ -22,6 +23,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/auth")
 public class AuthController {
+
+    private final SignupUserService signupUserService;
+
+    public AuthController(SignupUserService signupUserService) {
+        this.signupUserService = signupUserService;
+    }
 
     @Operation(
             summary = "회원가입",
@@ -49,6 +56,6 @@ public class AuthController {
     ) {
         return ResponseEntity
                 .status(HttpStatus.CREATED)
-                .body(ApiResponse.ok(ApiCode.AUTH201, SignupResponse.from(request)));
+                .body(ApiResponse.ok(ApiCode.AUTH201, SignupResponse.from(signupUserService.saveUser(request))));
     }
 }

--- a/src/main/java/com/campost/backend/domain/auth/dto/SignupResponse.java
+++ b/src/main/java/com/campost/backend/domain/auth/dto/SignupResponse.java
@@ -1,5 +1,6 @@
 package com.campost.backend.domain.auth.dto;
 
+import com.campost.backend.domain.auth.model.User;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "회원가입 응답")
@@ -14,6 +15,13 @@ public record SignupResponse(
         return new SignupResponse(
                 request.username(),
                 request.email()
+        );
+    }
+
+    public static SignupResponse from(User user) {
+        return new SignupResponse(
+                user.username(),
+                user.email()
         );
     }
 }

--- a/src/main/java/com/campost/backend/domain/auth/model/SignupUserCreateCommand.java
+++ b/src/main/java/com/campost/backend/domain/auth/model/SignupUserCreateCommand.java
@@ -1,0 +1,8 @@
+package com.campost.backend.domain.auth.model;
+
+public record SignupUserCreateCommand(
+        String username,
+        String email,
+        String passwordHash
+) {
+}

--- a/src/main/java/com/campost/backend/domain/auth/model/User.java
+++ b/src/main/java/com/campost/backend/domain/auth/model/User.java
@@ -1,0 +1,13 @@
+package com.campost.backend.domain.auth.model;
+
+import java.time.OffsetDateTime;
+
+public record User(
+        long id,
+        String username,
+        String email,
+        String passwordHash,
+        String role,
+        OffsetDateTime createdAt
+) {
+}

--- a/src/main/java/com/campost/backend/domain/auth/repository/JdbcUserRepository.java
+++ b/src/main/java/com/campost/backend/domain/auth/repository/JdbcUserRepository.java
@@ -1,0 +1,39 @@
+package com.campost.backend.domain.auth.repository;
+
+import com.campost.backend.domain.auth.model.SignupUserCreateCommand;
+import com.campost.backend.domain.auth.model.User;
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class JdbcUserRepository implements UserRepository {
+
+    private final JdbcClient jdbcClient;
+
+    public JdbcUserRepository(JdbcClient jdbcClient) {
+        this.jdbcClient = jdbcClient;
+    }
+
+    @Override
+    public User save(SignupUserCreateCommand command) {
+        String sql = """
+                INSERT INTO users (username, email, password_hash, role)
+                VALUES (:username, :email, :passwordHash, 'GUEST')
+                RETURNING id, username, email, password_hash, role, created_at
+                """;
+
+        return jdbcClient.sql(sql)
+                .param("username", command.username())
+                .param("email", command.email())
+                .param("passwordHash", command.passwordHash())
+                .query((rs, rowNum) -> new User(
+                        rs.getLong("id"),
+                        rs.getString("username"),
+                        rs.getString("email"),
+                        rs.getString("password_hash"),
+                        rs.getString("role"),
+                        rs.getObject("created_at", java.time.OffsetDateTime.class)
+                ))
+                .single();
+    }
+}

--- a/src/main/java/com/campost/backend/domain/auth/repository/UserRepository.java
+++ b/src/main/java/com/campost/backend/domain/auth/repository/UserRepository.java
@@ -1,0 +1,9 @@
+package com.campost.backend.domain.auth.repository;
+
+import com.campost.backend.domain.auth.model.SignupUserCreateCommand;
+import com.campost.backend.domain.auth.model.User;
+
+public interface UserRepository {
+
+    User save(SignupUserCreateCommand command);
+}

--- a/src/main/java/com/campost/backend/domain/auth/service/PasswordHashService.java
+++ b/src/main/java/com/campost/backend/domain/auth/service/PasswordHashService.java
@@ -1,0 +1,66 @@
+package com.campost.backend.domain.auth.service;
+
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.security.spec.InvalidKeySpecException;
+import java.util.Base64;
+
+@Component
+public class PasswordHashService {
+
+    private static final String ALGORITHM = "PBKDF2WithHmacSHA256";
+    private static final int ITERATIONS = 120_000;
+    private static final int KEY_LENGTH = 256;
+    private static final int SALT_LENGTH = 16;
+    private static final String FORMAT = "pbkdf2_sha256";
+
+    private final SecureRandom secureRandom = new SecureRandom();
+
+    public String hash(String rawPassword) {
+        byte[] salt = new byte[SALT_LENGTH];
+        secureRandom.nextBytes(salt);
+
+        byte[] hash = pbkdf2(rawPassword.toCharArray(), salt);
+
+        return String.join(
+                "$",
+                FORMAT,
+                String.valueOf(ITERATIONS),
+                Base64.getEncoder().encodeToString(salt),
+                Base64.getEncoder().encodeToString(hash)
+        );
+    }
+
+    public boolean matches(String rawPassword, String encodedPassword) {
+        String[] parts = encodedPassword.split("\\$");
+
+        if (parts.length != 4 || !FORMAT.equals(parts[0])) {
+            return false;
+        }
+
+        int iterations = Integer.parseInt(parts[1]);
+        byte[] salt = Base64.getDecoder().decode(parts[2]);
+        byte[] expectedHash = Base64.getDecoder().decode(parts[3]);
+        byte[] actualHash = pbkdf2(rawPassword.toCharArray(), salt, iterations);
+
+        return java.security.MessageDigest.isEqual(expectedHash, actualHash);
+    }
+
+    private byte[] pbkdf2(char[] password, byte[] salt) {
+        return pbkdf2(password, salt, ITERATIONS);
+    }
+
+    private byte[] pbkdf2(char[] password, byte[] salt, int iterations) {
+        try {
+            PBEKeySpec spec = new PBEKeySpec(password, salt, iterations, KEY_LENGTH);
+            SecretKeyFactory factory = SecretKeyFactory.getInstance(ALGORITHM);
+            return factory.generateSecret(spec).getEncoded();
+        } catch (NoSuchAlgorithmException | InvalidKeySpecException ex) {
+            throw new IllegalStateException("Failed to hash password.", ex);
+        }
+    }
+}

--- a/src/main/java/com/campost/backend/domain/auth/service/SignupUserService.java
+++ b/src/main/java/com/campost/backend/domain/auth/service/SignupUserService.java
@@ -1,0 +1,34 @@
+package com.campost.backend.domain.auth.service;
+
+import com.campost.backend.domain.auth.dto.SignupRequest;
+import com.campost.backend.domain.auth.model.SignupUserCreateCommand;
+import com.campost.backend.domain.auth.model.User;
+import com.campost.backend.domain.auth.repository.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class SignupUserService {
+
+    private final UserRepository userRepository;
+    private final PasswordHashService passwordHashService;
+
+    public SignupUserService(
+            UserRepository userRepository,
+            PasswordHashService passwordHashService
+    ) {
+        this.userRepository = userRepository;
+        this.passwordHashService = passwordHashService;
+    }
+
+    @Transactional
+    public User saveUser(SignupRequest request) {
+        String passwordHash = passwordHashService.hash(request.password());
+
+        return userRepository.save(new SignupUserCreateCommand(
+                request.username(),
+                request.email(),
+                passwordHash
+        ));
+    }
+}

--- a/src/main/resources/db/migration/V7__add_username_to_users.sql
+++ b/src/main/resources/db/migration/V7__add_username_to_users.sql
@@ -1,0 +1,18 @@
+-- ============================================================
+-- Add username for signup
+-- ============================================================
+
+ALTER TABLE users
+    ADD COLUMN IF NOT EXISTS username VARCHAR(20);
+
+UPDATE users
+SET username = CASE
+    WHEN email = 'admin@dankook.ac.kr' THEN 'admin01'
+    ELSE 'user' || LPAD(id::TEXT, 6, '0')
+END
+WHERE username IS NULL;
+
+ALTER TABLE users
+    ALTER COLUMN username SET NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_users_username ON users(username);

--- a/src/test/java/com/campost/backend/domain/auth/service/PasswordHashServiceTest.java
+++ b/src/test/java/com/campost/backend/domain/auth/service/PasswordHashServiceTest.java
@@ -1,0 +1,30 @@
+package com.campost.backend.domain.auth.service;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PasswordHashServiceTest {
+
+    private final PasswordHashService passwordHashService = new PasswordHashService();
+
+    @Test
+    void hashDoesNotStoreRawPassword() {
+        String rawPassword = "password123";
+
+        String passwordHash = passwordHashService.hash(rawPassword);
+
+        assertThat(passwordHash).isNotEqualTo(rawPassword);
+        assertThat(passwordHash).doesNotContain(rawPassword);
+        assertThat(passwordHash).startsWith("pbkdf2_sha256$");
+    }
+
+    @Test
+    void matchesReturnsTrueForOriginalPassword() {
+        String rawPassword = "password123";
+        String passwordHash = passwordHashService.hash(rawPassword);
+
+        assertThat(passwordHashService.matches(rawPassword, passwordHash)).isTrue();
+        assertThat(passwordHashService.matches("wrongPassword123", passwordHash)).isFalse();
+    }
+}

--- a/src/test/java/com/campost/backend/domain/auth/service/SignupUserServiceTest.java
+++ b/src/test/java/com/campost/backend/domain/auth/service/SignupUserServiceTest.java
@@ -1,0 +1,59 @@
+package com.campost.backend.domain.auth.service;
+
+import com.campost.backend.domain.auth.dto.SignupRequest;
+import com.campost.backend.domain.auth.model.SignupUserCreateCommand;
+import com.campost.backend.domain.auth.model.User;
+import com.campost.backend.domain.auth.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+
+import java.time.OffsetDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SignupUserServiceTest {
+
+    private final FakeUserRepository userRepository = new FakeUserRepository();
+    private final PasswordHashService passwordHashService = new PasswordHashService();
+    private final SignupUserService signupUserService = new SignupUserService(
+            userRepository,
+            passwordHashService
+    );
+
+    @Test
+    void saveUserHashesPasswordBeforeSaving() {
+        SignupRequest request = new SignupRequest(
+                "campost123",
+                "campost@example.com",
+                "password123"
+        );
+
+        User savedUser = signupUserService.saveUser(request);
+        SignupUserCreateCommand savedCommand = userRepository.savedCommand;
+
+        assertThat(savedCommand.username()).isEqualTo(request.username());
+        assertThat(savedCommand.email()).isEqualTo(request.email());
+        assertThat(savedCommand.passwordHash()).isNotEqualTo(request.password());
+        assertThat(savedCommand.passwordHash()).doesNotContain(request.password());
+        assertThat(passwordHashService.matches(request.password(), savedCommand.passwordHash())).isTrue();
+        assertThat(savedUser.passwordHash()).isEqualTo(savedCommand.passwordHash());
+    }
+
+    private static class FakeUserRepository implements UserRepository {
+
+        private SignupUserCreateCommand savedCommand;
+
+        @Override
+        public User save(SignupUserCreateCommand command) {
+            this.savedCommand = command;
+
+            return new User(
+                    1L,
+                    command.username(),
+                    command.email(),
+                    command.passwordHash(),
+                    "GUEST",
+                    OffsetDateTime.now()
+            );
+        }
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #22 

## 🏷️ PR 타입

- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)
- [ ] ⚙️ 프로젝트 초기 설정 (Chore)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🚨 PR 복구 (Revert)

## 📝 작업 내용

## 작업 내용

### 1. 사용자 저장을 위한 DB 스키마 확장
- 기존 `users` 테이블에 `username` 컬럼을 추가했습니다.
- `username`은 회원가입 시 사용하는 아이디 값으로 저장됩니다.
- 데이터 정합성을 위해 `username`에 `NOT NULL`, `UNIQUE` 제약 조건을 적용했습니다.
- 기존 사용자 데이터가 있는 경우를 고려해 마이그레이션에서 기본 username을 채워 넣도록 처리했습니다.

### 2. 회원가입 사용자 저장 로직 추가
- 회원가입 요청 정보를 저장하기 위한 사용자 모델을 추가했습니다.
- `SignupUserService`를 추가해 회원가입 요청을 사용자 저장 로직으로 연결했습니다.
- `UserRepository` / `JdbcUserRepository`를 추가해 `users` 테이블에 사용자 정보를 저장하도록 구현했습니다.
- 회원가입 성공 시 저장된 사용자 정보를 기반으로 응답을 반환하도록 `AuthController`를 수정했습니다.

### 3. 비밀번호 해시 처리
- `PasswordHashService`를 추가했습니다.
- 사용자가 입력한 비밀번호는 DB에 저장되기 전에 PBKDF2 기반 단방향 해시로 변환됩니다.
- DB에는 평문 비밀번호가 저장되지 않고 `password_hash` 값만 저장됩니다.

### 4. 테스트 추가
- 비밀번호 해시 서비스 테스트를 추가했습니다.
- 회원가입 저장 서비스 테스트를 추가했습니다.
- 저장 시 비밀번호가 평문으로 저장되지 않는지 검증했습니다.
- 원본 비밀번호와 해시된 비밀번호가 정상적으로 매칭되는지 검증했습니다.

## 테스트

- [x] `.\mvnw.cmd test`

## 참고

- 이메일 중복 사전 검사 로직은 다음 PR에서 구현 예정입니다.
- 이번 PR에서는 사용자 기본 정보 저장과 비밀번호 해시 처리에 집중했습니다.


## 📸 스크린샷

- 테스트 결과를 스크린샷으로 첨부해주세요.

## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다.
- [x] 코드 스타일 가이드를 준수했습니다.
- [x] 셀프 리뷰를 완료했습니다.
- [x] 테스트를 작성하고 모두 통과했습니다.
- [ ] 문서를 업데이트했습니다. (필요한 경우)

## 📎 기타 참고사항

- 논의가 필요한 부분, 리뷰 시 유의사항 등을 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
- 사용자가 사용자명, 이메일 및 비밀번호로 새 계정을 생성할 수 있습니다
- 모든 비밀번호는 최신 암호화 기술로 안전하게 저장됩니다

## 테스트
- 회원가입 프로세스 및 비밀번호 보안 검증 관련 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->