### PR TITLE
Feat(#24): 중복 이메일 검사 로직 구현

### DIFF
--- a/src/main/java/com/campost/backend/domain/auth/exception/DuplicatedEmailException.java
+++ b/src/main/java/com/campost/backend/domain/auth/exception/DuplicatedEmailException.java
@@ -1,0 +1,8 @@
+package com.campost.backend.domain.auth.exception;
+
+public class DuplicatedEmailException extends RuntimeException {
+
+    public DuplicatedEmailException() {
+        super("이미 가입된 이메일입니다.");
+    }
+}

--- a/src/main/java/com/campost/backend/domain/auth/repository/JdbcUserRepository.java
+++ b/src/main/java/com/campost/backend/domain/auth/repository/JdbcUserRepository.java
@@ -36,4 +36,20 @@ public class JdbcUserRepository implements UserRepository {
                 ))
                 .single();
     }
+
+    @Override
+    public boolean existsByEmail(String email) {
+        String sql = """
+                SELECT EXISTS (
+                    SELECT 1
+                    FROM users
+                    WHERE email = :email
+                )
+                """;
+
+        return Boolean.TRUE.equals(jdbcClient.sql(sql)
+                .param("email", email)
+                .query(Boolean.class)
+                .single());
+    }
 }

--- a/src/main/java/com/campost/backend/domain/auth/repository/UserRepository.java
+++ b/src/main/java/com/campost/backend/domain/auth/repository/UserRepository.java
@@ -6,4 +6,6 @@ import com.campost.backend.domain.auth.model.User;
 public interface UserRepository {
 
     User save(SignupUserCreateCommand command);
+
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/com/campost/backend/domain/auth/service/SignupUserService.java
+++ b/src/main/java/com/campost/backend/domain/auth/service/SignupUserService.java
@@ -8,6 +8,8 @@ import com.campost.backend.domain.auth.repository.UserRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Locale;
+
 @Service
 public class SignupUserService {
 
@@ -24,7 +26,9 @@ public class SignupUserService {
 
     @Transactional
     public User saveUser(SignupRequest request) {
-        if (userRepository.existsByEmail(request.email())) {
+        String normalizedEmail = normalizeEmail(request.email());
+
+        if (userRepository.existsByEmail(normalizedEmail)) {
             throw new DuplicatedEmailException();
         }
 
@@ -32,8 +36,12 @@ public class SignupUserService {
 
         return userRepository.save(new SignupUserCreateCommand(
                 request.username(),
-                request.email(),
+                normalizedEmail,
                 passwordHash
         ));
+    }
+
+    private String normalizeEmail(String email) {
+        return email.trim().toLowerCase(Locale.ROOT);
     }
 }

--- a/src/main/java/com/campost/backend/domain/auth/service/SignupUserService.java
+++ b/src/main/java/com/campost/backend/domain/auth/service/SignupUserService.java
@@ -1,6 +1,7 @@
 package com.campost.backend.domain.auth.service;
 
 import com.campost.backend.domain.auth.dto.SignupRequest;
+import com.campost.backend.domain.auth.exception.DuplicatedEmailException;
 import com.campost.backend.domain.auth.model.SignupUserCreateCommand;
 import com.campost.backend.domain.auth.model.User;
 import com.campost.backend.domain.auth.repository.UserRepository;
@@ -23,6 +24,10 @@ public class SignupUserService {
 
     @Transactional
     public User saveUser(SignupRequest request) {
+        if (userRepository.existsByEmail(request.email())) {
+            throw new DuplicatedEmailException();
+        }
+
         String passwordHash = passwordHashService.hash(request.password());
 
         return userRepository.save(new SignupUserCreateCommand(

--- a/src/main/java/com/campost/backend/global/api/ApiCode.java
+++ b/src/main/java/com/campost/backend/global/api/ApiCode.java
@@ -5,6 +5,7 @@ import org.springframework.http.HttpStatus;
 public enum ApiCode {
     COMMON200(HttpStatus.OK, "COMMON200", "요청이 성공했습니다."),
     AUTH201(HttpStatus.CREATED, "AUTH201", "회원가입 요청 형식 검증에 성공했습니다."),
+    AUTH409(HttpStatus.CONFLICT, "AUTH409", "이미 가입된 이메일입니다."),
     COMMON400(HttpStatus.BAD_REQUEST, "COMMON400", "잘못된 요청입니다."),
     TOKEN401(HttpStatus.UNAUTHORIZED, "TOKEN401", "액세스 토큰이 만료되었습니다."),
     TOKEN402(HttpStatus.UNAUTHORIZED, "TOKEN402", "유효하지 않은 토큰입니다."),

--- a/src/main/java/com/campost/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/campost/backend/global/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.campost.backend.global.exception;
 
+import com.campost.backend.domain.auth.exception.DuplicatedEmailException;
 import com.campost.backend.global.api.ApiCode;
 import com.campost.backend.global.api.ErrorResponse;
 import jakarta.validation.ConstraintViolationException;
@@ -61,6 +62,11 @@ public class GlobalExceptionHandler {
         return toResponse(ApiCode.COMMON409);
     }
 
+    @ExceptionHandler(DuplicatedEmailException.class)
+    public ResponseEntity<ErrorResponse> handleDuplicatedEmail(DuplicatedEmailException ex) {
+        return toResponse(ApiCode.AUTH409, ex.getMessage());
+    }
+
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleGenericException(Exception ex) {
         return toResponse(ApiCode.SERVER500);
@@ -69,5 +75,10 @@ public class GlobalExceptionHandler {
     private ResponseEntity<ErrorResponse> toResponse(ApiCode code) {
         return ResponseEntity.status(Objects.requireNonNull(code.httpStatus()))
                 .body(ErrorResponse.of(code));
+    }
+
+    private ResponseEntity<ErrorResponse> toResponse(ApiCode code, String message) {
+        return ResponseEntity.status(Objects.requireNonNull(code.httpStatus()))
+                .body(ErrorResponse.of(code, message));
     }
 }

--- a/src/main/java/com/campost/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/campost/backend/global/exception/GlobalExceptionHandler.java
@@ -64,7 +64,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(DuplicatedEmailException.class)
     public ResponseEntity<ErrorResponse> handleDuplicatedEmail(DuplicatedEmailException ex) {
-        return toResponse(ApiCode.AUTH409, ex.getMessage());
+        return toResponse(ApiCode.AUTH409);
     }
 
     @ExceptionHandler(Exception.class)
@@ -75,10 +75,5 @@ public class GlobalExceptionHandler {
     private ResponseEntity<ErrorResponse> toResponse(ApiCode code) {
         return ResponseEntity.status(Objects.requireNonNull(code.httpStatus()))
                 .body(ErrorResponse.of(code));
-    }
-
-    private ResponseEntity<ErrorResponse> toResponse(ApiCode code, String message) {
-        return ResponseEntity.status(Objects.requireNonNull(code.httpStatus()))
-                .body(ErrorResponse.of(code, message));
     }
 }

--- a/src/test/java/com/campost/backend/domain/auth/service/SignupUserServiceTest.java
+++ b/src/test/java/com/campost/backend/domain/auth/service/SignupUserServiceTest.java
@@ -1,6 +1,7 @@
 package com.campost.backend.domain.auth.service;
 
 import com.campost.backend.domain.auth.dto.SignupRequest;
+import com.campost.backend.domain.auth.exception.DuplicatedEmailException;
 import com.campost.backend.domain.auth.model.SignupUserCreateCommand;
 import com.campost.backend.domain.auth.model.User;
 import com.campost.backend.domain.auth.repository.UserRepository;
@@ -9,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import java.time.OffsetDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class SignupUserServiceTest {
 
@@ -38,9 +40,41 @@ class SignupUserServiceTest {
         assertThat(savedUser.passwordHash()).isEqualTo(savedCommand.passwordHash());
     }
 
+    @Test
+    void saveUserThrowsExceptionWhenEmailAlreadyExists() {
+        SignupRequest request = new SignupRequest(
+                "campost123",
+                "campost@example.com",
+                "password123"
+        );
+        userRepository.emailExists = true;
+
+        assertThatThrownBy(() -> signupUserService.saveUser(request))
+                .isInstanceOf(DuplicatedEmailException.class)
+                .hasMessage("이미 가입된 이메일입니다.");
+
+        assertThat(userRepository.savedCommand).isNull();
+    }
+
+    @Test
+    void saveUserStoresUserWhenEmailDoesNotExist() {
+        SignupRequest request = new SignupRequest(
+                "campost123",
+                "campost@example.com",
+                "password123"
+        );
+        userRepository.emailExists = false;
+
+        signupUserService.saveUser(request);
+
+        assertThat(userRepository.savedCommand).isNotNull();
+        assertThat(userRepository.savedCommand.email()).isEqualTo(request.email());
+    }
+
     private static class FakeUserRepository implements UserRepository {
 
         private SignupUserCreateCommand savedCommand;
+        private boolean emailExists;
 
         @Override
         public User save(SignupUserCreateCommand command) {
@@ -54,6 +88,11 @@ class SignupUserServiceTest {
                     "GUEST",
                     OffsetDateTime.now()
             );
+        }
+
+        @Override
+        public boolean existsByEmail(String email) {
+            return emailExists;
         }
     }
 }

--- a/src/test/java/com/campost/backend/domain/auth/service/SignupUserServiceTest.java
+++ b/src/test/java/com/campost/backend/domain/auth/service/SignupUserServiceTest.java
@@ -71,9 +71,24 @@ class SignupUserServiceTest {
         assertThat(userRepository.savedCommand.email()).isEqualTo(request.email());
     }
 
+    @Test
+    void saveUserNormalizesEmailBeforeDuplicateCheckAndSave() {
+        SignupRequest request = new SignupRequest(
+                "campost123",
+                " User@example.com ",
+                "password123"
+        );
+
+        signupUserService.saveUser(request);
+
+        assertThat(userRepository.checkedEmail).isEqualTo("user@example.com");
+        assertThat(userRepository.savedCommand.email()).isEqualTo("user@example.com");
+    }
+
     private static class FakeUserRepository implements UserRepository {
 
         private SignupUserCreateCommand savedCommand;
+        private String checkedEmail;
         private boolean emailExists;
 
         @Override
@@ -92,6 +107,7 @@ class SignupUserServiceTest {
 
         @Override
         public boolean existsByEmail(String email) {
+            this.checkedEmail = email;
             return emailExists;
         }
     }


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #24 

## 🏷️ PR 타입

- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)
- [ ] ⚙️ 프로젝트 초기 설정 (Chore)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🚨 PR 복구 (Revert)

## 📝 작업 내용

## 작업 내용

### 1. 이메일 중복 확인 Repository 로직 추가
- `UserRepository`에 `existsByEmail(email)` 메서드를 추가했습니다.
- `JdbcUserRepository`에서 `users` 테이블을 조회해 이메일 존재 여부를 확인하도록 구현했습니다.
- 회원가입 저장 전에 동일 이메일이 이미 존재하는지 확인할 수 있게 했습니다.

### 2. 회원가입 저장 전 이메일 중복 검사 추가
- `SignupUserService`에서 사용자 저장 전에 `existsByEmail`을 호출하도록 수정했습니다.
- 이미 가입된 이메일이면 사용자 저장을 진행하지 않고 예외를 발생시킵니다.
- 중복 이메일인 경우 비밀번호 해시 및 DB 저장 로직까지 가지 않도록 차단했습니다.

### 3. 중복 이메일 예외 및 409 응답 처리
- `DuplicatedEmailException`을 추가했습니다.
- 중복 이메일 발생 시 `409 Conflict`로 응답하도록 `GlobalExceptionHandler`에 처리 로직을 추가했습니다.
- 응답 메시지는 `"이미 가입된 이메일입니다."`로 명확하게 반환되도록 했습니다.
- `ApiCode`에 `AUTH409` 코드를 추가했습니다.

### 4. 테스트 추가
- 이메일이 이미 존재하는 경우 `DuplicatedEmailException`이 발생하는지 테스트했습니다.
- 중복 이메일인 경우 저장 로직이 호출되지 않는지 검증했습니다.
- 이메일이 중복되지 않은 경우 정상적으로 저장 로직이 진행되는지 테스트했습니다.


### 코드리뷰 반영

- 이메일 중복 검사 전 이메일을 소문자/trim 처리하도록 정규화했습니다.
- 정규화된 이메일을 중복 검사와 저장에 동일하게 사용하도록 수정했습니다.
- `DuplicatedEmailException` 응답 처리를 `ApiCode.AUTH409` 기반으로 단순화했습니다.
- 사용하지 않는 예외 응답 오버로드 메서드를 제거했습니다.
- 이메일 정규화 테스트를 추가했습니다.


## 테스트

- [x] `.\mvnw.cmd test`

## 참고

- 이번 PR은 이메일 중복 검사에만 집중했습니다.
- 아이디 중복 검사와 이메일 인증 API는 후속 PR에서 별도로 구현 예정입니다.


## 📸 스크린샷

- 테스트 결과를 스크린샷으로 첨부해주세요.

## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다.
- [x] 코드 스타일 가이드를 준수했습니다.
- [x] 셀프 리뷰를 완료했습니다.
- [x] 테스트를 작성하고 모두 통과했습니다.
- [ ] 문서를 업데이트했습니다. (필요한 경우)

## 📎 기타 참고사항

- 논의가 필요한 부분, 리뷰 시 유의사항 등을 작성해주세요.
