### PR TITLE
feat: 이메일 인증 메일 발송 구현 (#37)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,10 @@
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-mail</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
             <version>2.8.6</version>

--- a/src/main/java/com/campost/backend/domain/auth/exception/EmailVerificationSendException.java
+++ b/src/main/java/com/campost/backend/domain/auth/exception/EmailVerificationSendException.java
@@ -1,0 +1,8 @@
+package com.campost.backend.domain.auth.exception;
+
+public class EmailVerificationSendException extends RuntimeException {
+
+    public EmailVerificationSendException(Throwable cause) {
+        super("이메일 인증번호 발송에 실패했습니다.", cause);
+    }
+}

--- a/src/main/java/com/campost/backend/domain/auth/service/EmailVerificationPolicy.java
+++ b/src/main/java/com/campost/backend/domain/auth/service/EmailVerificationPolicy.java
@@ -1,0 +1,9 @@
+package com.campost.backend.domain.auth.service;
+
+public final class EmailVerificationPolicy {
+
+    public static final long CODE_TTL_MINUTES = 5;
+
+    private EmailVerificationPolicy() {
+    }
+}

--- a/src/main/java/com/campost/backend/domain/auth/service/EmailVerificationService.java
+++ b/src/main/java/com/campost/backend/domain/auth/service/EmailVerificationService.java
@@ -14,8 +14,6 @@ import java.util.Locale;
 @Service
 public class EmailVerificationService {
 
-    private static final long CODE_TTL_MINUTES = 5;
-
     private final EmailVerificationCodeIssueService emailVerificationCodeIssueService;
     private final EmailVerificationCodeVerifyService emailVerificationCodeVerifyService;
     private final VerificationCodeHashService verificationCodeHashService;
@@ -43,7 +41,8 @@ public class EmailVerificationService {
         String normalizedEmail = normalizeEmail(request.email());
         String code = verificationCodeGenerator.generate();
         String codeHash = verificationCodeHashService.hash(code);
-        OffsetDateTime expiresAt = OffsetDateTime.now(clock).plusMinutes(CODE_TTL_MINUTES);
+        OffsetDateTime expiresAt = OffsetDateTime.now(clock)
+                .plusMinutes(EmailVerificationPolicy.CODE_TTL_MINUTES);
 
         emailVerificationCodeIssueService.issueCode(new EmailVerificationCodeCreateCommand(
                 normalizedEmail,

--- a/src/main/java/com/campost/backend/domain/auth/service/LoggingEmailVerificationSender.java
+++ b/src/main/java/com/campost/backend/domain/auth/service/LoggingEmailVerificationSender.java
@@ -2,9 +2,15 @@ package com.campost.backend.domain.auth.service;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 @Component
+@ConditionalOnProperty(
+        name = "app.mail.verification-sender",
+        havingValue = "logging",
+        matchIfMissing = true
+)
 public class LoggingEmailVerificationSender implements EmailVerificationSender {
 
     private static final Logger log = LoggerFactory.getLogger(LoggingEmailVerificationSender.class);

--- a/src/main/java/com/campost/backend/domain/auth/service/SmtpEmailVerificationSender.java
+++ b/src/main/java/com/campost/backend/domain/auth/service/SmtpEmailVerificationSender.java
@@ -1,0 +1,44 @@
+package com.campost.backend.domain.auth.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnProperty(
+        name = "app.mail.verification-sender",
+        havingValue = "smtp"
+)
+public class SmtpEmailVerificationSender implements EmailVerificationSender {
+
+    private final JavaMailSender mailSender;
+    private final String from;
+
+    public SmtpEmailVerificationSender(
+            JavaMailSender mailSender,
+            @Value("${app.mail.from}") String from
+    ) {
+        this.mailSender = mailSender;
+        this.from = from;
+    }
+
+    @Override
+    public void send(String email, String code) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setFrom(from);
+        message.setTo(email);
+        message.setSubject("CamPost 이메일 인증번호");
+        message.setText("""
+                CamPost 회원가입 이메일 인증번호입니다.
+
+                인증번호: %s
+
+                인증번호는 5분 동안 유효합니다.
+                본인이 요청하지 않았다면 이 메일을 무시해주세요.
+                """.formatted(code));
+
+        mailSender.send(message);
+    }
+}

--- a/src/main/java/com/campost/backend/domain/auth/service/SmtpEmailVerificationSender.java
+++ b/src/main/java/com/campost/backend/domain/auth/service/SmtpEmailVerificationSender.java
@@ -1,7 +1,11 @@
 package com.campost.backend.domain.auth.service;
 
+import com.campost.backend.domain.auth.exception.EmailVerificationSendException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.mail.MailException;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Component;
@@ -12,6 +16,8 @@ import org.springframework.stereotype.Component;
         havingValue = "smtp"
 )
 public class SmtpEmailVerificationSender implements EmailVerificationSender {
+
+    private static final Logger log = LoggerFactory.getLogger(SmtpEmailVerificationSender.class);
 
     private final JavaMailSender mailSender;
     private final String from;
@@ -35,10 +41,28 @@ public class SmtpEmailVerificationSender implements EmailVerificationSender {
 
                 인증번호: %s
 
-                인증번호는 5분 동안 유효합니다.
+                인증번호는 %d분 동안 유효합니다.
                 본인이 요청하지 않았다면 이 메일을 무시해주세요.
-                """.formatted(code));
+                """.formatted(code, EmailVerificationPolicy.CODE_TTL_MINUTES));
 
-        mailSender.send(message);
+        try {
+            mailSender.send(message);
+        } catch (MailException exception) {
+            log.warn(
+                    "Failed to send email verification code. email={}, reason={}",
+                    maskEmail(email),
+                    exception.getMessage()
+            );
+            throw new EmailVerificationSendException(exception);
+        }
+    }
+
+    private String maskEmail(String email) {
+        int atIndex = email.indexOf('@');
+        if (atIndex <= 1) {
+            return "***" + email.substring(Math.max(atIndex, 0));
+        }
+
+        return email.charAt(0) + "***" + email.substring(atIndex);
     }
 }

--- a/src/main/java/com/campost/backend/global/api/ApiCode.java
+++ b/src/main/java/com/campost/backend/global/api/ApiCode.java
@@ -6,6 +6,7 @@ public enum ApiCode {
     COMMON200(HttpStatus.OK, "COMMON200", "요청이 성공했습니다."),
     AUTH201(HttpStatus.CREATED, "AUTH201", "회원가입 요청 형식 검증에 성공했습니다."),
     AUTH400_EMAIL_VERIFICATION(HttpStatus.BAD_REQUEST, "AUTH400_EMAIL_VERIFICATION", "이메일 인증번호가 유효하지 않습니다."),
+    AUTH503_EMAIL_VERIFICATION_SEND(HttpStatus.SERVICE_UNAVAILABLE, "AUTH503_EMAIL_VERIFICATION_SEND", "이메일 인증번호 발송에 실패했습니다."),
     AUTH409(HttpStatus.CONFLICT, "AUTH409", "이미 가입된 이메일입니다."),
     AUTH409_USERNAME(HttpStatus.CONFLICT, "AUTH409_USERNAME", "이미 사용 중인 아이디입니다."),
     COMMON400(HttpStatus.BAD_REQUEST, "COMMON400", "잘못된 요청입니다."),

--- a/src/main/java/com/campost/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/campost/backend/global/exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.campost.backend.global.exception;
 
 import com.campost.backend.domain.auth.exception.DuplicatedEmailException;
 import com.campost.backend.domain.auth.exception.DuplicatedUsernameException;
+import com.campost.backend.domain.auth.exception.EmailVerificationSendException;
 import com.campost.backend.domain.auth.exception.InvalidEmailVerificationCodeException;
 import com.campost.backend.domain.auth.exception.UnverifiedEmailException;
 import com.campost.backend.global.api.ApiCode;
@@ -96,6 +97,11 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(UnverifiedEmailException.class)
     public ResponseEntity<ErrorResponse> handleUnverifiedEmail(UnverifiedEmailException ex) {
         return toResponse(ApiCode.AUTH400_EMAIL_VERIFICATION);
+    }
+
+    @ExceptionHandler(EmailVerificationSendException.class)
+    public ResponseEntity<ErrorResponse> handleEmailVerificationSend(EmailVerificationSendException ex) {
+        return toResponse(ApiCode.AUTH503_EMAIL_VERIFICATION_SEND);
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,6 +28,9 @@ springdoc:
 app:
   cors:
     allowed-origins: ${APP_CORS_ALLOWED_ORIGINS}
+  mail:
+    verification-sender: ${APP_MAIL_VERIFICATION_SENDER:logging}
+    from: ${APP_MAIL_FROM:no-reply@campost.local}
   importer:
     enabled: ${IMPORTER_ENABLED:true}
     raw-store-dir: ${RAW_STORE_DIR:/data/raw}

--- a/src/test/java/com/campost/backend/domain/auth/service/SmtpEmailVerificationSenderTest.java
+++ b/src/test/java/com/campost/backend/domain/auth/service/SmtpEmailVerificationSenderTest.java
@@ -1,0 +1,79 @@
+package com.campost.backend.domain.auth.service;
+
+import jakarta.mail.Session;
+import jakarta.mail.internet.MimeMessage;
+import org.junit.jupiter.api.Test;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessagePreparator;
+
+import java.io.InputStream;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SmtpEmailVerificationSenderTest {
+
+    private final FakeJavaMailSender mailSender = new FakeJavaMailSender();
+    private final SmtpEmailVerificationSender sender =
+            new SmtpEmailVerificationSender(mailSender, "no-reply@campost.local");
+
+    @Test
+    void sendCreatesVerificationEmailMessage() {
+        sender.send("user@example.com", "123456");
+
+        SimpleMailMessage sentMessage = mailSender.sentMessage;
+
+        assertThat(sentMessage).isNotNull();
+        assertThat(sentMessage.getFrom()).isEqualTo("no-reply@campost.local");
+        assertThat(sentMessage.getTo()).containsExactly("user@example.com");
+        assertThat(sentMessage.getSubject()).isEqualTo("CamPost 이메일 인증번호");
+        assertThat(sentMessage.getText()).contains("123456");
+        assertThat(sentMessage.getText()).contains("5분");
+    }
+
+    private static class FakeJavaMailSender implements JavaMailSender {
+
+        private SimpleMailMessage sentMessage;
+
+        @Override
+        public MimeMessage createMimeMessage() {
+            return new MimeMessage(Session.getInstance(new Properties()));
+        }
+
+        @Override
+        public MimeMessage createMimeMessage(InputStream contentStream) {
+            throw new UnsupportedOperationException("Not used in this test.");
+        }
+
+        @Override
+        public void send(MimeMessage mimeMessage) {
+            throw new UnsupportedOperationException("Not used in this test.");
+        }
+
+        @Override
+        public void send(MimeMessage... mimeMessages) {
+            throw new UnsupportedOperationException("Not used in this test.");
+        }
+
+        @Override
+        public void send(MimeMessagePreparator mimeMessagePreparator) {
+            throw new UnsupportedOperationException("Not used in this test.");
+        }
+
+        @Override
+        public void send(MimeMessagePreparator... mimeMessagePreparators) {
+            throw new UnsupportedOperationException("Not used in this test.");
+        }
+
+        @Override
+        public void send(SimpleMailMessage simpleMessage) {
+            this.sentMessage = simpleMessage;
+        }
+
+        @Override
+        public void send(SimpleMailMessage... simpleMessages) {
+            this.sentMessage = simpleMessages[0];
+        }
+    }
+}

--- a/src/test/java/com/campost/backend/domain/auth/service/SmtpEmailVerificationSenderTest.java
+++ b/src/test/java/com/campost/backend/domain/auth/service/SmtpEmailVerificationSenderTest.java
@@ -1,8 +1,10 @@
 package com.campost.backend.domain.auth.service;
 
+import com.campost.backend.domain.auth.exception.EmailVerificationSendException;
 import jakarta.mail.Session;
 import jakarta.mail.internet.MimeMessage;
 import org.junit.jupiter.api.Test;
+import org.springframework.mail.MailSendException;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessagePreparator;
@@ -11,6 +13,7 @@ import java.io.InputStream;
 import java.util.Properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class SmtpEmailVerificationSenderTest {
 
@@ -27,14 +30,24 @@ class SmtpEmailVerificationSenderTest {
         assertThat(sentMessage).isNotNull();
         assertThat(sentMessage.getFrom()).isEqualTo("no-reply@campost.local");
         assertThat(sentMessage.getTo()).containsExactly("user@example.com");
-        assertThat(sentMessage.getSubject()).isEqualTo("CamPost 이메일 인증번호");
+        assertThat(sentMessage.getSubject()).isNotBlank();
         assertThat(sentMessage.getText()).contains("123456");
-        assertThat(sentMessage.getText()).contains("5분");
+        assertThat(sentMessage.getText()).contains(String.valueOf(EmailVerificationPolicy.CODE_TTL_MINUTES));
+    }
+
+    @Test
+    void sendThrowsBusinessExceptionWhenMailSendFails() {
+        mailSender.failToSend = true;
+
+        assertThatThrownBy(() -> sender.send("user@example.com", "123456"))
+                .isInstanceOf(EmailVerificationSendException.class)
+                .hasCauseInstanceOf(MailSendException.class);
     }
 
     private static class FakeJavaMailSender implements JavaMailSender {
 
         private SimpleMailMessage sentMessage;
+        private boolean failToSend;
 
         @Override
         public MimeMessage createMimeMessage() {
@@ -68,12 +81,20 @@ class SmtpEmailVerificationSenderTest {
 
         @Override
         public void send(SimpleMailMessage simpleMessage) {
+            if (failToSend) {
+                throw new MailSendException("SMTP server unavailable.");
+            }
+
             this.sentMessage = simpleMessage;
         }
 
         @Override
         public void send(SimpleMailMessage... simpleMessages) {
-            this.sentMessage = simpleMessages[0];
+            if (simpleMessages.length == 0) {
+                throw new IllegalArgumentException("At least one message is required.");
+            }
+
+            send(simpleMessages[0]);
         }
     }
 }

--- a/src/test/java/com/campost/backend/global/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/campost/backend/global/exception/GlobalExceptionHandlerTest.java
@@ -1,5 +1,6 @@
 package com.campost.backend.global.exception;
 
+import com.campost.backend.domain.auth.exception.EmailVerificationSendException;
 import com.campost.backend.domain.auth.exception.InvalidEmailVerificationCodeException;
 import com.campost.backend.domain.auth.exception.UnverifiedEmailException;
 import com.campost.backend.global.api.ErrorResponse;
@@ -73,5 +74,16 @@ class GlobalExceptionHandlerTest {
         assertThat(response.getStatusCode().value()).isEqualTo(400);
         assertThat(response.getBody()).isNotNull();
         assertThat(response.getBody().code()).isEqualTo("AUTH400_EMAIL_VERIFICATION");
+    }
+
+    @Test
+    void handleEmailVerificationSendReturnsServiceUnavailableResponse() {
+        ResponseEntity<ErrorResponse> response = handler.handleEmailVerificationSend(
+                new EmailVerificationSendException(new RuntimeException("SMTP failure"))
+        );
+
+        assertThat(response.getStatusCode().value()).isEqualTo(503);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().code()).isEqualTo("AUTH503_EMAIL_VERIFICATION_SEND");
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #37 

## 🏷️ PR 타입

- [ ] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 🎨 스타일 변경 (Style)
- [x] ✅ 테스트 추가 (Test)
- [ ] ⚙️ 프로젝트 초기 설정 (Chore)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🚨 PR 복구 (Revert)

## 📝 작업 내용

- SMTP 기반 이메일 인증번호 발송 구현체를 추가했습니다.
  - `SmtpEmailVerificationSender`
  - `JavaMailSender`를 사용해 인증번호 메일 발송
  - 메일 제목/본문 구성
  - 인증번호 유효시간 5분 안내 포함

- 메일 발송 의존성을 추가했습니다.
  - `spring-boot-starter-mail`

- 이메일 인증 발송 구현체를 설정으로 선택할 수 있도록 구성했습니다.
  - 기본값: `logging`
  - SMTP 사용 시: `APP_MAIL_VERIFICATION_SENDER=smtp`

- 기존 `LoggingEmailVerificationSender`는 fallback 용도로 유지했습니다.
  - `app.mail.verification-sender=logging`일 때만 활성화
  - 기본값도 logging이라 현재 Docker 환경에서 SMTP 설정 없이도 기존처럼 동작

- 발신자 설정을 추가했습니다.
  - `APP_MAIL_FROM`
  - 기본값: `no-reply@campost.local`

- SMTP 메일 생성 단위 테스트를 추가했습니다.
  - 수신자, 발신자, 제목, 인증번호 본문 포함 여부 검증

## 코드리뷰 반영 내용

- SMTP 메일 발송 실패 예외 처리를 추가했습니다.
  - `mailSender.send(message)`에서 `MailException` 발생 시 캐치
  - 마스킹된 이메일과 실패 사유를 WARN 로그로 기록
  - `EmailVerificationSendException`으로 변환하여 throw

- 이메일 인증번호 발송 실패 전용 응답을 추가했습니다.
  - `AUTH503_EMAIL_VERIFICATION_SEND`
  - HTTP Status: `503 Service Unavailable`
  - SMTP 서버 연결 실패/인증 실패 등 외부 메일 시스템 문제를 일반 500이 아닌 명확한 응답으로 처리

- 인증번호 유효시간을 공통 정책으로 분리했습니다.
  - `EmailVerificationPolicy.CODE_TTL_MINUTES`
  - `EmailVerificationService`의 만료시간 계산과 `SmtpEmailVerificationSender`의 메일 본문이 같은 값을 참조하도록 수정

- 테스트용 Fake `JavaMailSender`의 배열 접근을 보강했습니다.
  - `send(SimpleMailMessage... simpleMessages)`에서 빈 배열이면 명시적으로 예외 발생
  - 기존처럼 바로 `simpleMessages[0]`에 접근하지 않도록 수정

## 테스트

- `.\mvnw.cmd test`

### 결과

- Tests run: 30
- Failures: 0
- Errors: 0
- BUILD SUCCESS


## 📸 스크린샷

- 테스트 결과를 스크린샷으로 첨부해주세요.

## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다.
- [x] 코드 스타일 가이드를 준수했습니다.
- [x] 셀프 리뷰를 완료했습니다.
- [x] 테스트를 작성하고 모두 통과했습니다.
- [x] 문서를 업데이트했습니다. (필요한 경우)

## 📎 기타 참고사항

- 논의가 필요한 부분, 리뷰 시 유의사항 등을 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 이메일 인증 기능이 추가되었습니다. 사용자는 이메일을 통해 인증 코드를 수신할 수 있습니다.
  * 인증 코드는 SMTP를 통해 실제 이메일로 전송되거나 로깅 모드로 기록될 수 있습니다.
  * 기본적으로 로깅 모드가 활성화되어 있으며, 필요에 따라 SMTP 모드로 변경하여 실제 이메일 전송이 가능합니다.
  * 이메일 발신자 주소와 인증 방식은 설정을 통해 커스터마이징할 수 있습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Team-CamPost/CamPost-backend/pull/38)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->