### PR TITLE
chore: 개발용 Mailpit 환경 구성 (#39)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,18 @@ APP_CORS_ALLOWED_ORIGINS=<REQUIRED>
 JWT_SECRET=<REQUIRED>
 JWT_EXPIRY_MS=<REQUIRED>
 
+# Development email verification
+# Mailpit Web UI: http://localhost:8025
+# Mailpit SMTP host inside Docker Compose: mailpit:1025
+APP_MAIL_VERIFICATION_SENDER=smtp
+APP_MAIL_FROM=no-reply@campost.local
+SPRING_MAIL_HOST=mailpit
+SPRING_MAIL_PORT=1025
+SPRING_MAIL_USERNAME=
+SPRING_MAIL_PASSWORD=
+SPRING_MAIL_PROPERTIES_MAIL_SMTP_AUTH=false
+SPRING_MAIL_PROPERTIES_MAIL_SMTP_STARTTLS_ENABLE=false
+
 # ── Python Crawler ───────────────────────────────────────────
 OUTPUT_DIR=./data
 CRAWL_INTERVAL_MINUTES=60

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,14 @@ services:
       timeout: 5s
       retries: 5
 
+  mailpit:
+    image: axllent/mailpit:latest
+    container_name: campost-mailpit
+    restart: unless-stopped
+    ports:
+      - "1025:1025"
+      - "8025:8025"
+
   # ── Spring Boot API + Importer + AIUpdater ─────────────────
   backend:
     build:
@@ -49,6 +57,14 @@ services:
       OPENAI_API_KEY:             ${OPENAI_API_KEY}
       AI_MODEL:                   ${AI_MODEL}
       AI_MOCK:                    ${AI_MOCK}
+      APP_MAIL_VERIFICATION_SENDER: ${APP_MAIL_VERIFICATION_SENDER:-smtp}
+      APP_MAIL_FROM:                ${APP_MAIL_FROM:-no-reply@campost.local}
+      SPRING_MAIL_HOST:             ${SPRING_MAIL_HOST:-mailpit}
+      SPRING_MAIL_PORT:             ${SPRING_MAIL_PORT:-1025}
+      SPRING_MAIL_USERNAME:         ${SPRING_MAIL_USERNAME:-}
+      SPRING_MAIL_PASSWORD:         ${SPRING_MAIL_PASSWORD:-}
+      SPRING_MAIL_PROPERTIES_MAIL_SMTP_AUTH:             ${SPRING_MAIL_PROPERTIES_MAIL_SMTP_AUTH:-false}
+      SPRING_MAIL_PROPERTIES_MAIL_SMTP_STARTTLS_ENABLE:  ${SPRING_MAIL_PROPERTIES_MAIL_SMTP_STARTTLS_ENABLE:-false}
     ports:
       - "8080:8080"
     healthcheck:
@@ -61,6 +77,8 @@ services:
     depends_on:
       db:
         condition: service_healthy
+      mailpit:
+        condition: service_started
 
   # ── Python Crawler Pipeline ────────────────────────────────
   pipeline:


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #39 
- 
## 🏷️ PR 타입

- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)
- [x] ⚙️ 프로젝트 초기 설정 (Chore)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🚨 PR 복구 (Revert)

## 📝 작업 내용

## 작업 내용

- Docker Compose에 개발용 Mailpit 서비스 추가
  - SMTP: `localhost:1025`
  - Web UI: `http://localhost:8025`
- backend 컨테이너에서 Mailpit SMTP를 사용하도록 개발용 메일 환경 변수 추가
- `.env.example`에 Mailpit 기반 이메일 인증 설정 예시 추가
- backend가 Mailpit 서비스 시작 이후 실행되도록 `depends_on` 구성 보강

## 확인 사항

- `docker compose config --quiet` 정상 통과
- `./mvnw test` 정상 통과
  - Tests run: 30
  - Failures: 0
  - Errors: 0
- `docker compose up -d --build mailpit backend` 실행 확인
- `campost-mailpit`, `campost-backend`, `campost-db` 컨테이너 정상 실행 및 healthy 확인
- 이메일 인증번호 전송 API 호출 후 Mailpit Web UI에서 인증 메일 수신 확인


## 📸 스크린샷

<img width="1920" height="1030" alt="image" src="https://github.com/user-attachments/assets/1415cf98-331e-4e89-a528-2fe5e768a6ea" />

## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다.
- [x] 코드 스타일 가이드를 준수했습니다.
- [x] 셀프 리뷰를 완료했습니다.
- [x] 테스트를 작성하고 모두 통과했습니다.
- [ ] 문서를 업데이트했습니다. (필요한 경우)

## 📎 기타 참고사항

- 논의가 필요한 부분, 리뷰 시 유의사항 등을 작성해주세요.
