### PR TITLE
Feat(#45):사용자 온보딩 프로필 저장 API 구현

### DIFF
--- a/src/main/java/com/campost/backend/domain/auth/repository/JdbcUserRepository.java
+++ b/src/main/java/com/campost/backend/domain/auth/repository/JdbcUserRepository.java
@@ -2,6 +2,8 @@ package com.campost.backend.domain.auth.repository;
 
 import com.campost.backend.domain.auth.model.SignupUserCreateCommand;
 import com.campost.backend.domain.auth.model.User;
+import com.campost.backend.domain.user.model.UserOnboardingProfile;
+import com.campost.backend.domain.user.model.UserOnboardingProfileUpdateCommand;
 import org.springframework.jdbc.core.simple.JdbcClient;
 import org.springframework.stereotype.Repository;
 
@@ -91,6 +93,33 @@ public class JdbcUserRepository implements UserRepository {
                         rs.getString("password_hash"),
                         rs.getString("role"),
                         rs.getObject("created_at", java.time.OffsetDateTime.class)
+                ))
+                .optional();
+    }
+
+    @Override
+    public Optional<UserOnboardingProfile> updateOnboardingProfile(UserOnboardingProfileUpdateCommand command) {
+        String sql = """
+                UPDATE users
+                SET department = :department,
+                    grade = :grade,
+                    name = :nickname,
+                    profile_completed = true
+                WHERE id = :userId
+                RETURNING id, department, grade, name, profile_completed
+                """;
+
+        return jdbcClient.sql(sql)
+                .param("department", command.department())
+                .param("grade", command.grade())
+                .param("nickname", command.nickname())
+                .param("userId", command.userId())
+                .query((rs, rowNum) -> new UserOnboardingProfile(
+                        rs.getLong("id"),
+                        rs.getString("department"),
+                        rs.getInt("grade"),
+                        rs.getString("name"),
+                        rs.getBoolean("profile_completed")
                 ))
                 .optional();
     }

--- a/src/main/java/com/campost/backend/domain/auth/repository/UserRepository.java
+++ b/src/main/java/com/campost/backend/domain/auth/repository/UserRepository.java
@@ -2,6 +2,8 @@ package com.campost.backend.domain.auth.repository;
 
 import com.campost.backend.domain.auth.model.SignupUserCreateCommand;
 import com.campost.backend.domain.auth.model.User;
+import com.campost.backend.domain.user.model.UserOnboardingProfile;
+import com.campost.backend.domain.user.model.UserOnboardingProfileUpdateCommand;
 
 import java.util.Optional;
 
@@ -14,4 +16,6 @@ public interface UserRepository {
     boolean existsByUsername(String username);
 
     Optional<User> findByUsername(String username);
+
+    Optional<UserOnboardingProfile> updateOnboardingProfile(UserOnboardingProfileUpdateCommand command);
 }

--- a/src/main/java/com/campost/backend/domain/user/controller/UserProfileController.java
+++ b/src/main/java/com/campost/backend/domain/user/controller/UserProfileController.java
@@ -1,0 +1,94 @@
+package com.campost.backend.domain.user.controller;
+
+import com.campost.backend.domain.user.dto.OnboardingProfileRequest;
+import com.campost.backend.domain.user.dto.OnboardingProfileResponse;
+import com.campost.backend.domain.user.service.UserOnboardingProfileService;
+import com.campost.backend.global.api.ApiResponse;
+import com.campost.backend.global.api.ErrorResponse;
+import com.campost.backend.global.exception.InvalidTokenException;
+import com.campost.backend.global.jwt.JwtTokenService;
+import io.jsonwebtoken.Claims;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "User", description = "사용자 API")
+@RestController
+@RequestMapping("/api/v1/users")
+public class UserProfileController {
+
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final UserOnboardingProfileService userOnboardingProfileService;
+    private final JwtTokenService jwtTokenService;
+
+    public UserProfileController(
+            UserOnboardingProfileService userOnboardingProfileService,
+            JwtTokenService jwtTokenService
+    ) {
+        this.userOnboardingProfileService = userOnboardingProfileService;
+        this.jwtTokenService = jwtTokenService;
+    }
+
+    @Operation(
+            summary = "첫 로그인 온보딩 프로필 저장",
+            description = "로그인한 사용자의 학과, 학년, 닉네임을 저장하고 프로필 설정 완료 상태로 변경합니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "온보딩 프로필 저장 성공"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "입력값 검증 실패",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "인증 토큰 누락, 만료 또는 유효하지 않은 토큰",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "사용자를 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+    @PatchMapping("/me/onboarding-profile")
+    public ApiResponse<OnboardingProfileResponse> saveOnboardingProfile(
+            @RequestHeader(name = "Authorization", required = false) String authorization,
+            @Valid @RequestBody OnboardingProfileRequest request
+    ) {
+        long userId = resolveUserId(authorization);
+
+        return ApiResponse.ok(OnboardingProfileResponse.from(
+                userOnboardingProfileService.saveProfile(userId, request)
+        ));
+    }
+
+    private long resolveUserId(String authorization) {
+        if (authorization == null || !authorization.startsWith(BEARER_PREFIX)) {
+            throw new InvalidTokenException("Missing bearer token.");
+        }
+
+        String token = authorization.substring(BEARER_PREFIX.length()).trim();
+        Claims claims = jwtTokenService.parse(token);
+
+        try {
+            return Long.parseLong(claims.getSubject());
+        } catch (NumberFormatException ex) {
+            throw new InvalidTokenException("Invalid token subject.");
+        }
+    }
+}

--- a/src/main/java/com/campost/backend/domain/user/dto/OnboardingProfileRequest.java
+++ b/src/main/java/com/campost/backend/domain/user/dto/OnboardingProfileRequest.java
@@ -1,0 +1,36 @@
+package com.campost.backend.domain.user.dto;
+
+import com.campost.backend.domain.user.validation.UserProfileValidationRules;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "첫 로그인 온보딩 프로필 저장 요청")
+public record OnboardingProfileRequest(
+        @Schema(description = "학과 코드", example = "SW")
+        @NotBlank(message = "학과를 선택해주세요.")
+        @Pattern(
+                regexp = UserProfileValidationRules.DEPARTMENT_CODE_PATTERN,
+                message = UserProfileValidationRules.DEPARTMENT_CODE_MESSAGE
+        )
+        String department,
+
+        @Schema(description = "학년", example = "3")
+        @NotNull(message = "학년을 선택해주세요.")
+        @Min(value = UserProfileValidationRules.MIN_GRADE, message = "학년은 1 이상이어야 합니다.")
+        @Max(value = UserProfileValidationRules.MAX_GRADE, message = "학년은 6 이하이어야 합니다.")
+        Integer grade,
+
+        @Schema(description = "닉네임", example = "캠포스트유저")
+        @NotBlank(message = "닉네임을 입력해주세요.")
+        @Size(
+                max = UserProfileValidationRules.MAX_NICKNAME_LENGTH,
+                message = "닉네임은 50자 이하로 입력해주세요."
+        )
+        String nickname
+) {
+}

--- a/src/main/java/com/campost/backend/domain/user/dto/OnboardingProfileResponse.java
+++ b/src/main/java/com/campost/backend/domain/user/dto/OnboardingProfileResponse.java
@@ -1,0 +1,32 @@
+package com.campost.backend.domain.user.dto;
+
+import com.campost.backend.domain.user.model.UserOnboardingProfile;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "첫 로그인 온보딩 프로필 저장 응답")
+public record OnboardingProfileResponse(
+        @Schema(description = "사용자 ID", example = "1")
+        long userId,
+
+        @Schema(description = "학과 코드", example = "SW")
+        String department,
+
+        @Schema(description = "학년", example = "3")
+        int grade,
+
+        @Schema(description = "닉네임", example = "캠포스트유저")
+        String nickname,
+
+        @Schema(description = "프로필 설정 완료 여부", example = "true")
+        boolean profileCompleted
+) {
+    public static OnboardingProfileResponse from(UserOnboardingProfile profile) {
+        return new OnboardingProfileResponse(
+                profile.userId(),
+                profile.department(),
+                profile.grade(),
+                profile.nickname(),
+                profile.profileCompleted()
+        );
+    }
+}

--- a/src/main/java/com/campost/backend/domain/user/exception/UserNotFoundException.java
+++ b/src/main/java/com/campost/backend/domain/user/exception/UserNotFoundException.java
@@ -1,0 +1,8 @@
+package com.campost.backend.domain.user.exception;
+
+public class UserNotFoundException extends RuntimeException {
+
+    public UserNotFoundException() {
+        super("User not found.");
+    }
+}

--- a/src/main/java/com/campost/backend/domain/user/model/UserOnboardingProfile.java
+++ b/src/main/java/com/campost/backend/domain/user/model/UserOnboardingProfile.java
@@ -1,0 +1,10 @@
+package com.campost.backend.domain.user.model;
+
+public record UserOnboardingProfile(
+        long userId,
+        String department,
+        int grade,
+        String nickname,
+        boolean profileCompleted
+) {
+}

--- a/src/main/java/com/campost/backend/domain/user/model/UserOnboardingProfileUpdateCommand.java
+++ b/src/main/java/com/campost/backend/domain/user/model/UserOnboardingProfileUpdateCommand.java
@@ -1,0 +1,9 @@
+package com.campost.backend.domain.user.model;
+
+public record UserOnboardingProfileUpdateCommand(
+        long userId,
+        String department,
+        int grade,
+        String nickname
+) {
+}

--- a/src/main/java/com/campost/backend/domain/user/service/UserOnboardingProfileService.java
+++ b/src/main/java/com/campost/backend/domain/user/service/UserOnboardingProfileService.java
@@ -2,12 +2,11 @@ package com.campost.backend.domain.user.service;
 
 import com.campost.backend.domain.auth.repository.UserRepository;
 import com.campost.backend.domain.user.dto.OnboardingProfileRequest;
+import com.campost.backend.domain.user.exception.UserNotFoundException;
 import com.campost.backend.domain.user.model.UserOnboardingProfile;
 import com.campost.backend.domain.user.model.UserOnboardingProfileUpdateCommand;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.NoSuchElementException;
 
 @Service
 public class UserOnboardingProfileService {
@@ -28,6 +27,6 @@ public class UserOnboardingProfileService {
         );
 
         return userRepository.updateOnboardingProfile(command)
-                .orElseThrow(() -> new NoSuchElementException("User not found."));
+                .orElseThrow(UserNotFoundException::new);
     }
 }

--- a/src/main/java/com/campost/backend/domain/user/service/UserOnboardingProfileService.java
+++ b/src/main/java/com/campost/backend/domain/user/service/UserOnboardingProfileService.java
@@ -1,0 +1,33 @@
+package com.campost.backend.domain.user.service;
+
+import com.campost.backend.domain.auth.repository.UserRepository;
+import com.campost.backend.domain.user.dto.OnboardingProfileRequest;
+import com.campost.backend.domain.user.model.UserOnboardingProfile;
+import com.campost.backend.domain.user.model.UserOnboardingProfileUpdateCommand;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.NoSuchElementException;
+
+@Service
+public class UserOnboardingProfileService {
+
+    private final UserRepository userRepository;
+
+    public UserOnboardingProfileService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Transactional
+    public UserOnboardingProfile saveProfile(long userId, OnboardingProfileRequest request) {
+        UserOnboardingProfileUpdateCommand command = new UserOnboardingProfileUpdateCommand(
+                userId,
+                request.department().trim(),
+                request.grade(),
+                request.nickname().trim()
+        );
+
+        return userRepository.updateOnboardingProfile(command)
+                .orElseThrow(() -> new NoSuchElementException("User not found."));
+    }
+}

--- a/src/main/java/com/campost/backend/domain/user/validation/UserProfileValidationRules.java
+++ b/src/main/java/com/campost/backend/domain/user/validation/UserProfileValidationRules.java
@@ -1,0 +1,13 @@
+package com.campost.backend.domain.user.validation;
+
+public final class UserProfileValidationRules {
+
+    public static final String DEPARTMENT_CODE_PATTERN = "SW|ACE|STAT|INDSEC|AI";
+    public static final String DEPARTMENT_CODE_MESSAGE = "지원하지 않는 학과입니다.";
+    public static final int MIN_GRADE = 1;
+    public static final int MAX_GRADE = 6;
+    public static final int MAX_NICKNAME_LENGTH = 50;
+
+    private UserProfileValidationRules() {
+    }
+}

--- a/src/main/java/com/campost/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/campost/backend/global/exception/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import com.campost.backend.domain.auth.exception.DuplicatedUsernameException;
 import com.campost.backend.domain.auth.exception.EmailVerificationSendException;
 import com.campost.backend.domain.auth.exception.InvalidEmailVerificationCodeException;
 import com.campost.backend.domain.auth.exception.UnverifiedEmailException;
+import com.campost.backend.domain.user.exception.UserNotFoundException;
 import com.campost.backend.global.api.ApiCode;
 import com.campost.backend.global.api.ErrorResponse;
 import jakarta.validation.ConstraintViolationException;
@@ -67,6 +68,11 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(NoSuchElementException.class)
     public ResponseEntity<ErrorResponse> handleNotFound(NoSuchElementException ex) {
+        return toResponse(ApiCode.COMMON404);
+    }
+
+    @ExceptionHandler(UserNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleUserNotFound(UserNotFoundException ex) {
         return toResponse(ApiCode.COMMON404);
     }
 

--- a/src/main/resources/db/migration/V12__add_user_onboarding_profile.sql
+++ b/src/main/resources/db/migration/V12__add_user_onboarding_profile.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users
+    ADD COLUMN IF NOT EXISTS profile_completed BOOLEAN NOT NULL DEFAULT false;

--- a/src/test/java/com/campost/backend/domain/auth/service/EmailVerificationServiceTest.java
+++ b/src/test/java/com/campost/backend/domain/auth/service/EmailVerificationServiceTest.java
@@ -12,6 +12,8 @@ import com.campost.backend.domain.auth.model.SignupUserCreateCommand;
 import com.campost.backend.domain.auth.model.User;
 import com.campost.backend.domain.auth.repository.EmailVerificationRepository;
 import com.campost.backend.domain.auth.repository.UserRepository;
+import com.campost.backend.domain.user.model.UserOnboardingProfile;
+import com.campost.backend.domain.user.model.UserOnboardingProfileUpdateCommand;
 import org.junit.jupiter.api.Test;
 
 import java.time.Clock;
@@ -179,6 +181,11 @@ class EmailVerificationServiceTest {
 
         @Override
         public java.util.Optional<User> findByUsername(String username) {
+            throw new UnsupportedOperationException("Not used in this test.");
+        }
+
+        @Override
+        public Optional<UserOnboardingProfile> updateOnboardingProfile(UserOnboardingProfileUpdateCommand command) {
             throw new UnsupportedOperationException("Not used in this test.");
         }
     }

--- a/src/test/java/com/campost/backend/domain/auth/service/LoginServiceTest.java
+++ b/src/test/java/com/campost/backend/domain/auth/service/LoginServiceTest.java
@@ -5,6 +5,8 @@ import com.campost.backend.domain.auth.exception.BadCredentialsException;
 import com.campost.backend.domain.auth.model.SignupUserCreateCommand;
 import com.campost.backend.domain.auth.model.User;
 import com.campost.backend.domain.auth.repository.UserRepository;
+import com.campost.backend.domain.user.model.UserOnboardingProfile;
+import com.campost.backend.domain.user.model.UserOnboardingProfileUpdateCommand;
 import com.campost.backend.global.jwt.JwtTokenService;
 import org.junit.jupiter.api.Test;
 
@@ -80,6 +82,11 @@ class LoginServiceTest {
         @Override
         public Optional<User> findByUsername(String username) {
             return foundUser;
+        }
+
+        @Override
+        public Optional<UserOnboardingProfile> updateOnboardingProfile(UserOnboardingProfileUpdateCommand command) {
+            throw new UnsupportedOperationException("Not used in this test.");
         }
     }
 

--- a/src/test/java/com/campost/backend/domain/auth/service/SignupUserServiceTest.java
+++ b/src/test/java/com/campost/backend/domain/auth/service/SignupUserServiceTest.java
@@ -10,6 +10,8 @@ import com.campost.backend.domain.auth.model.EmailVerificationCode;
 import com.campost.backend.domain.auth.model.EmailVerificationCodeCreateCommand;
 import com.campost.backend.domain.auth.repository.EmailVerificationRepository;
 import com.campost.backend.domain.auth.repository.UserRepository;
+import com.campost.backend.domain.user.model.UserOnboardingProfile;
+import com.campost.backend.domain.user.model.UserOnboardingProfileUpdateCommand;
 import org.junit.jupiter.api.Test;
 
 import java.time.OffsetDateTime;
@@ -215,6 +217,11 @@ class SignupUserServiceTest {
 
         @Override
         public java.util.Optional<User> findByUsername(String username) {
+            throw new UnsupportedOperationException("Not used in this test.");
+        }
+
+        @Override
+        public Optional<UserOnboardingProfile> updateOnboardingProfile(UserOnboardingProfileUpdateCommand command) {
             throw new UnsupportedOperationException("Not used in this test.");
         }
     }

--- a/src/test/java/com/campost/backend/domain/user/dto/OnboardingProfileRequestValidationTest.java
+++ b/src/test/java/com/campost/backend/domain/user/dto/OnboardingProfileRequestValidationTest.java
@@ -1,0 +1,37 @@
+package com.campost.backend.domain.user.dto;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OnboardingProfileRequestValidationTest {
+
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+    @Test
+    void validatesRequiredFields() {
+        OnboardingProfileRequest request = new OnboardingProfileRequest("", null, "");
+
+        assertThat(validator.validate(request)).hasSizeGreaterThanOrEqualTo(3);
+    }
+
+    @Test
+    void validatesDepartmentGradeAndNicknameRules() {
+        OnboardingProfileRequest request = new OnboardingProfileRequest(
+                "UNKNOWN",
+                7,
+                "a".repeat(51)
+        );
+
+        assertThat(validator.validate(request)).hasSize(3);
+    }
+
+    @Test
+    void acceptsValidRequest() {
+        OnboardingProfileRequest request = new OnboardingProfileRequest("SW", 3, "캠포스트유저");
+
+        assertThat(validator.validate(request)).isEmpty();
+    }
+}

--- a/src/test/java/com/campost/backend/domain/user/service/UserOnboardingProfileServiceTest.java
+++ b/src/test/java/com/campost/backend/domain/user/service/UserOnboardingProfileServiceTest.java
@@ -1,0 +1,90 @@
+package com.campost.backend.domain.user.service;
+
+import com.campost.backend.domain.auth.model.SignupUserCreateCommand;
+import com.campost.backend.domain.auth.model.User;
+import com.campost.backend.domain.auth.repository.UserRepository;
+import com.campost.backend.domain.user.dto.OnboardingProfileRequest;
+import com.campost.backend.domain.user.model.UserOnboardingProfile;
+import com.campost.backend.domain.user.model.UserOnboardingProfileUpdateCommand;
+import org.junit.jupiter.api.Test;
+
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class UserOnboardingProfileServiceTest {
+
+    private final FakeUserRepository userRepository = new FakeUserRepository();
+    private final UserOnboardingProfileService service = new UserOnboardingProfileService(userRepository);
+
+    @Test
+    void saveProfileTrimsNicknameAndMarksProfileCompleted() {
+        OnboardingProfileRequest request = new OnboardingProfileRequest(
+                "SW",
+                3,
+                " 캠포스트유저 "
+        );
+
+        UserOnboardingProfile profile = service.saveProfile(1L, request);
+
+        assertThat(userRepository.savedCommand.userId()).isEqualTo(1L);
+        assertThat(userRepository.savedCommand.department()).isEqualTo("SW");
+        assertThat(userRepository.savedCommand.grade()).isEqualTo(3);
+        assertThat(userRepository.savedCommand.nickname()).isEqualTo("캠포스트유저");
+        assertThat(profile.nickname()).isEqualTo("캠포스트유저");
+        assertThat(profile.profileCompleted()).isTrue();
+    }
+
+    @Test
+    void saveProfileThrowsExceptionWhenUserDoesNotExist() {
+        userRepository.updatedProfile = Optional.empty();
+        OnboardingProfileRequest request = new OnboardingProfileRequest("SW", 2, "캠포스트유저");
+
+        assertThatThrownBy(() -> service.saveProfile(999L, request))
+                .isInstanceOf(NoSuchElementException.class);
+    }
+
+    private static class FakeUserRepository implements UserRepository {
+
+        private UserOnboardingProfileUpdateCommand savedCommand;
+        private Optional<UserOnboardingProfile> updatedProfile;
+
+        @Override
+        public User save(SignupUserCreateCommand command) {
+            throw new UnsupportedOperationException("Not used in this test.");
+        }
+
+        @Override
+        public boolean existsByEmail(String email) {
+            throw new UnsupportedOperationException("Not used in this test.");
+        }
+
+        @Override
+        public boolean existsByUsername(String username) {
+            throw new UnsupportedOperationException("Not used in this test.");
+        }
+
+        @Override
+        public Optional<User> findByUsername(String username) {
+            throw new UnsupportedOperationException("Not used in this test.");
+        }
+
+        @Override
+        public Optional<UserOnboardingProfile> updateOnboardingProfile(UserOnboardingProfileUpdateCommand command) {
+            this.savedCommand = command;
+            if (updatedProfile != null) {
+                return updatedProfile;
+            }
+
+            return Optional.of(new UserOnboardingProfile(
+                    command.userId(),
+                    command.department(),
+                    command.grade(),
+                    command.nickname(),
+                    true
+            ));
+        }
+    }
+}

--- a/src/test/java/com/campost/backend/domain/user/service/UserOnboardingProfileServiceTest.java
+++ b/src/test/java/com/campost/backend/domain/user/service/UserOnboardingProfileServiceTest.java
@@ -4,11 +4,11 @@ import com.campost.backend.domain.auth.model.SignupUserCreateCommand;
 import com.campost.backend.domain.auth.model.User;
 import com.campost.backend.domain.auth.repository.UserRepository;
 import com.campost.backend.domain.user.dto.OnboardingProfileRequest;
+import com.campost.backend.domain.user.exception.UserNotFoundException;
 import com.campost.backend.domain.user.model.UserOnboardingProfile;
 import com.campost.backend.domain.user.model.UserOnboardingProfileUpdateCommand;
 import org.junit.jupiter.api.Test;
 
-import java.util.NoSuchElementException;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -43,7 +43,7 @@ class UserOnboardingProfileServiceTest {
         OnboardingProfileRequest request = new OnboardingProfileRequest("SW", 2, "캠포스트유저");
 
         assertThatThrownBy(() -> service.saveProfile(999L, request))
-                .isInstanceOf(NoSuchElementException.class);
+                .isInstanceOf(UserNotFoundException.class);
     }
 
     private static class FakeUserRepository implements UserRepository {


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #45 

## 🏷️ PR 타입

- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)
- [ ] ⚙️ 프로젝트 초기 설정 (Chore)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🚨 PR 복구 (Revert)

## 📝 작업 내용

- 첫 로그인 온보딩 프로필 저장 API 추가
  - `PATCH /api/v1/users/me/onboarding-profile`
  - JWT Bearer 토큰에서 사용자 ID를 추출해 본인 프로필 저장
- 온보딩 프로필 요청/응답 DTO 추가
  - 학과, 학년, 닉네임 validation 적용
  - Swagger schema 반영
- 사용자 프로필 저장 로직 추가
  - `users.department`
  - `users.grade`
  - `users.name`을 닉네임으로 저장
  - 저장 완료 시 `profile_completed = true`
- `users` 테이블에 `profile_completed` 컬럼 추가 Flyway migration 작성
- 사용자 프로필 저장 repository/service 로직 추가
- 온보딩 프로필 validation 및 service 단위 테스트 추가

## 확인 사항

- `./mvnw test` 통과
  - Tests run: 39
  - Failures: 0
  - Errors: 0

## 코드리뷰 반영 내용

- 온보딩 프로필 저장 대상 사용자가 없을 때 `NoSuchElementException` 대신 `UserNotFoundException`을 사용하도록 변경
- `UserNotFoundException`을 전역 예외 핸들러에서 404 응답으로 매핑
- 관련 서비스 테스트의 기대 예외 타입 수정

## 반영하지 않은 리뷰

- `department`, `grade` 컬럼 추가
  - 기존 `V3__user_personal_admin_schema.sql`에 이미 존재하여 중복 추가하지 않음
- 컨트롤러 JWT 파싱 로직의 `@AuthenticationPrincipal` 전환
  - 현재 Spring Security 기반 인증 구조가 없어 이번 PR 범위를 벗어난다고 판단

## 확인 사항

- `./mvnw test` 통과
  - Tests run: 39
  - Failures: 0
  - Errors: 0


## 📸 스크린샷

- 테스트 결과를 스크린샷으로 첨부해주세요.

## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다.
- [x] 코드 스타일 가이드를 준수했습니다.
- [x] 셀프 리뷰를 완료했습니다.
- [x] 테스트를 작성하고 모두 통과했습니다.
- [x] 문서를 업데이트했습니다. (필요한 경우)

## 📎 기타 참고사항

- 논의가 필요한 부분, 리뷰 시 유의사항 등을 작성해주세요.
