### PR TITLE
Feat(#49): 사용자 프로필 정보 수정 API 구현

### DIFF
--- a/src/main/java/com/campost/backend/domain/auth/repository/JdbcUserRepository.java
+++ b/src/main/java/com/campost/backend/domain/auth/repository/JdbcUserRepository.java
@@ -6,6 +6,7 @@ import com.campost.backend.domain.user.model.UserOnboardingProfile;
 import com.campost.backend.domain.user.model.UserOnboardingProfileUpdateCommand;
 import com.campost.backend.domain.user.model.UserProfile;
 import com.campost.backend.domain.user.model.UserProfileUpdateCommand;
+import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.simple.JdbcClient;
 import org.springframework.stereotype.Repository;
 
@@ -13,6 +14,19 @@ import java.util.Optional;
 
 @Repository
 public class JdbcUserRepository implements UserRepository {
+
+    private static final RowMapper<UserProfile> USER_PROFILE_ROW_MAPPER = (rs, rowNum) -> new UserProfile(
+            rs.getLong("id"),
+            rs.getString("username"),
+            rs.getString("email"),
+            rs.getString("name"),
+            rs.getString("department"),
+            rs.getObject("grade", Integer.class),
+            rs.getString("role"),
+            rs.getBoolean("profile_completed"),
+            rs.getObject("created_at", java.time.OffsetDateTime.class),
+            rs.getObject("last_login_at", java.time.OffsetDateTime.class)
+    );
 
     private final JdbcClient jdbcClient;
 
@@ -110,18 +124,7 @@ public class JdbcUserRepository implements UserRepository {
 
         return jdbcClient.sql(sql)
                 .param("userId", userId)
-                .query((rs, rowNum) -> new UserProfile(
-                        rs.getLong("id"),
-                        rs.getString("username"),
-                        rs.getString("email"),
-                        rs.getString("name"),
-                        rs.getString("department"),
-                        rs.getObject("grade", Integer.class),
-                        rs.getString("role"),
-                        rs.getBoolean("profile_completed"),
-                        rs.getObject("created_at", java.time.OffsetDateTime.class),
-                        rs.getObject("last_login_at", java.time.OffsetDateTime.class)
-                ))
+                .query(USER_PROFILE_ROW_MAPPER)
                 .optional();
     }
 
@@ -142,18 +145,7 @@ public class JdbcUserRepository implements UserRepository {
                 .param("grade", command.grade())
                 .param("nickname", command.nickname())
                 .param("userId", command.userId())
-                .query((rs, rowNum) -> new UserProfile(
-                        rs.getLong("id"),
-                        rs.getString("username"),
-                        rs.getString("email"),
-                        rs.getString("name"),
-                        rs.getString("department"),
-                        rs.getObject("grade", Integer.class),
-                        rs.getString("role"),
-                        rs.getBoolean("profile_completed"),
-                        rs.getObject("created_at", java.time.OffsetDateTime.class),
-                        rs.getObject("last_login_at", java.time.OffsetDateTime.class)
-                ))
+                .query(USER_PROFILE_ROW_MAPPER)
                 .optional();
     }
 

--- a/src/main/java/com/campost/backend/domain/auth/repository/JdbcUserRepository.java
+++ b/src/main/java/com/campost/backend/domain/auth/repository/JdbcUserRepository.java
@@ -5,6 +5,7 @@ import com.campost.backend.domain.auth.model.User;
 import com.campost.backend.domain.user.model.UserOnboardingProfile;
 import com.campost.backend.domain.user.model.UserOnboardingProfileUpdateCommand;
 import com.campost.backend.domain.user.model.UserProfile;
+import com.campost.backend.domain.user.model.UserProfileUpdateCommand;
 import org.springframework.jdbc.core.simple.JdbcClient;
 import org.springframework.stereotype.Repository;
 
@@ -109,6 +110,38 @@ public class JdbcUserRepository implements UserRepository {
 
         return jdbcClient.sql(sql)
                 .param("userId", userId)
+                .query((rs, rowNum) -> new UserProfile(
+                        rs.getLong("id"),
+                        rs.getString("username"),
+                        rs.getString("email"),
+                        rs.getString("name"),
+                        rs.getString("department"),
+                        rs.getObject("grade", Integer.class),
+                        rs.getString("role"),
+                        rs.getBoolean("profile_completed"),
+                        rs.getObject("created_at", java.time.OffsetDateTime.class),
+                        rs.getObject("last_login_at", java.time.OffsetDateTime.class)
+                ))
+                .optional();
+    }
+
+    @Override
+    public Optional<UserProfile> updateProfile(UserProfileUpdateCommand command) {
+        String sql = """
+                UPDATE users
+                SET department = :department,
+                    grade = :grade,
+                    name = :nickname
+                WHERE id = :userId
+                RETURNING id, username, email, name, department, grade, role,
+                          profile_completed, created_at, last_login_at
+                """;
+
+        return jdbcClient.sql(sql)
+                .param("department", command.department())
+                .param("grade", command.grade())
+                .param("nickname", command.nickname())
+                .param("userId", command.userId())
                 .query((rs, rowNum) -> new UserProfile(
                         rs.getLong("id"),
                         rs.getString("username"),

--- a/src/main/java/com/campost/backend/domain/auth/repository/UserRepository.java
+++ b/src/main/java/com/campost/backend/domain/auth/repository/UserRepository.java
@@ -5,6 +5,7 @@ import com.campost.backend.domain.auth.model.User;
 import com.campost.backend.domain.user.model.UserOnboardingProfile;
 import com.campost.backend.domain.user.model.UserOnboardingProfileUpdateCommand;
 import com.campost.backend.domain.user.model.UserProfile;
+import com.campost.backend.domain.user.model.UserProfileUpdateCommand;
 
 import java.util.Optional;
 
@@ -19,6 +20,8 @@ public interface UserRepository {
     Optional<User> findByUsername(String username);
 
     Optional<UserProfile> findProfileById(long userId);
+
+    Optional<UserProfile> updateProfile(UserProfileUpdateCommand command);
 
     Optional<UserOnboardingProfile> updateOnboardingProfile(UserOnboardingProfileUpdateCommand command);
 }

--- a/src/main/java/com/campost/backend/domain/user/controller/UserProfileController.java
+++ b/src/main/java/com/campost/backend/domain/user/controller/UserProfileController.java
@@ -3,8 +3,10 @@ package com.campost.backend.domain.user.controller;
 import com.campost.backend.domain.user.dto.OnboardingProfileRequest;
 import com.campost.backend.domain.user.dto.OnboardingProfileResponse;
 import com.campost.backend.domain.user.dto.UserProfileResponse;
+import com.campost.backend.domain.user.dto.UserProfileUpdateRequest;
 import com.campost.backend.domain.user.service.UserOnboardingProfileService;
 import com.campost.backend.domain.user.service.UserProfileQueryService;
+import com.campost.backend.domain.user.service.UserProfileUpdateService;
 import com.campost.backend.global.api.ApiResponse;
 import com.campost.backend.global.api.ErrorResponse;
 import com.campost.backend.global.exception.InvalidTokenException;
@@ -33,16 +35,57 @@ public class UserProfileController {
 
     private final UserOnboardingProfileService userOnboardingProfileService;
     private final UserProfileQueryService userProfileQueryService;
+    private final UserProfileUpdateService userProfileUpdateService;
     private final JwtTokenService jwtTokenService;
 
     public UserProfileController(
             UserOnboardingProfileService userOnboardingProfileService,
             UserProfileQueryService userProfileQueryService,
+            UserProfileUpdateService userProfileUpdateService,
             JwtTokenService jwtTokenService
     ) {
         this.userOnboardingProfileService = userOnboardingProfileService;
         this.userProfileQueryService = userProfileQueryService;
+        this.userProfileUpdateService = userProfileUpdateService;
         this.jwtTokenService = jwtTokenService;
+    }
+
+    @Operation(
+            summary = "내 프로필 정보 수정",
+            description = "로그인한 사용자의 닉네임, 학과, 학년 정보를 수정합니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "프로필 정보 수정 성공"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "입력값 검증 실패",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "인증 토큰 누락, 만료 또는 유효하지 않은 토큰",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "사용자를 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+    @PatchMapping("/me/profile")
+    public ApiResponse<UserProfileResponse> updateMyProfile(
+            @RequestHeader(name = "Authorization", required = false) String authorization,
+            @Valid @RequestBody UserProfileUpdateRequest request
+    ) {
+        long userId = resolveUserId(authorization);
+
+        return ApiResponse.ok(UserProfileResponse.from(
+                userProfileUpdateService.updateProfile(userId, request)
+        ));
     }
 
     @Operation(

--- a/src/main/java/com/campost/backend/domain/user/dto/UserProfileUpdateRequest.java
+++ b/src/main/java/com/campost/backend/domain/user/dto/UserProfileUpdateRequest.java
@@ -29,7 +29,7 @@ public record UserProfileUpdateRequest(
         @NotBlank(message = "닉네임을 입력해주세요.")
         @Size(
                 max = UserProfileValidationRules.MAX_NICKNAME_LENGTH,
-                message = "닉네임은 50자 이하로 입력해주세요."
+                message = "닉네임은 {max}자 이하로 입력해주세요."
         )
         String nickname
 ) {

--- a/src/main/java/com/campost/backend/domain/user/dto/UserProfileUpdateRequest.java
+++ b/src/main/java/com/campost/backend/domain/user/dto/UserProfileUpdateRequest.java
@@ -1,0 +1,36 @@
+package com.campost.backend.domain.user.dto;
+
+import com.campost.backend.domain.user.validation.UserProfileValidationRules;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "사용자 프로필 정보 수정 요청")
+public record UserProfileUpdateRequest(
+        @Schema(description = "학과 코드", example = "SW")
+        @NotBlank(message = "학과를 선택해주세요.")
+        @Pattern(
+                regexp = UserProfileValidationRules.DEPARTMENT_CODE_PATTERN,
+                message = UserProfileValidationRules.DEPARTMENT_CODE_MESSAGE
+        )
+        String department,
+
+        @Schema(description = "학년", example = "3")
+        @NotNull(message = "학년을 선택해주세요.")
+        @Min(value = UserProfileValidationRules.MIN_GRADE, message = "학년은 1 이상이어야 합니다.")
+        @Max(value = UserProfileValidationRules.MAX_GRADE, message = "학년은 6 이하이어야 합니다.")
+        Integer grade,
+
+        @Schema(description = "닉네임", example = "캠포스트유저")
+        @NotBlank(message = "닉네임을 입력해주세요.")
+        @Size(
+                max = UserProfileValidationRules.MAX_NICKNAME_LENGTH,
+                message = "닉네임은 50자 이하로 입력해주세요."
+        )
+        String nickname
+) {
+}

--- a/src/main/java/com/campost/backend/domain/user/model/UserProfileUpdateCommand.java
+++ b/src/main/java/com/campost/backend/domain/user/model/UserProfileUpdateCommand.java
@@ -1,0 +1,9 @@
+package com.campost.backend.domain.user.model;
+
+public record UserProfileUpdateCommand(
+        long userId,
+        String department,
+        Integer grade,
+        String nickname
+) {
+}

--- a/src/main/java/com/campost/backend/domain/user/service/UserProfileUpdateService.java
+++ b/src/main/java/com/campost/backend/domain/user/service/UserProfileUpdateService.java
@@ -1,0 +1,32 @@
+package com.campost.backend.domain.user.service;
+
+import com.campost.backend.domain.auth.repository.UserRepository;
+import com.campost.backend.domain.user.dto.UserProfileUpdateRequest;
+import com.campost.backend.domain.user.exception.UserNotFoundException;
+import com.campost.backend.domain.user.model.UserProfile;
+import com.campost.backend.domain.user.model.UserProfileUpdateCommand;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class UserProfileUpdateService {
+
+    private final UserRepository userRepository;
+
+    public UserProfileUpdateService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Transactional
+    public UserProfile updateProfile(long userId, UserProfileUpdateRequest request) {
+        UserProfileUpdateCommand command = new UserProfileUpdateCommand(
+                userId,
+                request.department().trim(),
+                request.grade(),
+                request.nickname().trim()
+        );
+
+        return userRepository.updateProfile(command)
+                .orElseThrow(UserNotFoundException::new);
+    }
+}

--- a/src/main/java/com/campost/backend/domain/user/service/UserProfileUpdateService.java
+++ b/src/main/java/com/campost/backend/domain/user/service/UserProfileUpdateService.java
@@ -8,6 +8,8 @@ import com.campost.backend.domain.user.model.UserProfileUpdateCommand;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Objects;
+
 @Service
 public class UserProfileUpdateService {
 
@@ -21,12 +23,16 @@ public class UserProfileUpdateService {
     public UserProfile updateProfile(long userId, UserProfileUpdateRequest request) {
         UserProfileUpdateCommand command = new UserProfileUpdateCommand(
                 userId,
-                request.department().trim(),
+                trimRequired(request.department(), "department"),
                 request.grade(),
-                request.nickname().trim()
+                trimRequired(request.nickname(), "nickname")
         );
 
         return userRepository.updateProfile(command)
                 .orElseThrow(UserNotFoundException::new);
+    }
+
+    private String trimRequired(String value, String fieldName) {
+        return Objects.requireNonNull(value, fieldName + " must not be null.").trim();
     }
 }

--- a/src/test/java/com/campost/backend/domain/auth/service/EmailVerificationServiceTest.java
+++ b/src/test/java/com/campost/backend/domain/auth/service/EmailVerificationServiceTest.java
@@ -15,6 +15,7 @@ import com.campost.backend.domain.auth.repository.UserRepository;
 import com.campost.backend.domain.user.model.UserOnboardingProfile;
 import com.campost.backend.domain.user.model.UserOnboardingProfileUpdateCommand;
 import com.campost.backend.domain.user.model.UserProfile;
+import com.campost.backend.domain.user.model.UserProfileUpdateCommand;
 import org.junit.jupiter.api.Test;
 
 import java.time.Clock;
@@ -187,6 +188,11 @@ class EmailVerificationServiceTest {
 
         @Override
         public Optional<UserProfile> findProfileById(long userId) {
+            throw new UnsupportedOperationException("Not used in this test.");
+        }
+
+        @Override
+        public Optional<UserProfile> updateProfile(UserProfileUpdateCommand command) {
             throw new UnsupportedOperationException("Not used in this test.");
         }
 

--- a/src/test/java/com/campost/backend/domain/auth/service/LoginServiceTest.java
+++ b/src/test/java/com/campost/backend/domain/auth/service/LoginServiceTest.java
@@ -8,6 +8,7 @@ import com.campost.backend.domain.auth.repository.UserRepository;
 import com.campost.backend.domain.user.model.UserOnboardingProfile;
 import com.campost.backend.domain.user.model.UserOnboardingProfileUpdateCommand;
 import com.campost.backend.domain.user.model.UserProfile;
+import com.campost.backend.domain.user.model.UserProfileUpdateCommand;
 import com.campost.backend.global.jwt.JwtTokenService;
 import org.junit.jupiter.api.Test;
 
@@ -87,6 +88,11 @@ class LoginServiceTest {
 
         @Override
         public Optional<UserProfile> findProfileById(long userId) {
+            throw new UnsupportedOperationException("Not used in this test.");
+        }
+
+        @Override
+        public Optional<UserProfile> updateProfile(UserProfileUpdateCommand command) {
             throw new UnsupportedOperationException("Not used in this test.");
         }
 

--- a/src/test/java/com/campost/backend/domain/auth/service/SignupUserServiceTest.java
+++ b/src/test/java/com/campost/backend/domain/auth/service/SignupUserServiceTest.java
@@ -13,6 +13,7 @@ import com.campost.backend.domain.auth.repository.UserRepository;
 import com.campost.backend.domain.user.model.UserOnboardingProfile;
 import com.campost.backend.domain.user.model.UserOnboardingProfileUpdateCommand;
 import com.campost.backend.domain.user.model.UserProfile;
+import com.campost.backend.domain.user.model.UserProfileUpdateCommand;
 import org.junit.jupiter.api.Test;
 
 import java.time.OffsetDateTime;
@@ -223,6 +224,11 @@ class SignupUserServiceTest {
 
         @Override
         public Optional<UserProfile> findProfileById(long userId) {
+            throw new UnsupportedOperationException("Not used in this test.");
+        }
+
+        @Override
+        public Optional<UserProfile> updateProfile(UserProfileUpdateCommand command) {
             throw new UnsupportedOperationException("Not used in this test.");
         }
 

--- a/src/test/java/com/campost/backend/domain/user/dto/UserProfileUpdateRequestValidationTest.java
+++ b/src/test/java/com/campost/backend/domain/user/dto/UserProfileUpdateRequestValidationTest.java
@@ -1,0 +1,37 @@
+package com.campost.backend.domain.user.dto;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UserProfileUpdateRequestValidationTest {
+
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+    @Test
+    void validatesRequiredFields() {
+        UserProfileUpdateRequest request = new UserProfileUpdateRequest("", null, "");
+
+        assertThat(validator.validate(request)).hasSizeGreaterThanOrEqualTo(3);
+    }
+
+    @Test
+    void validatesDepartmentGradeAndNicknameRules() {
+        UserProfileUpdateRequest request = new UserProfileUpdateRequest(
+                "UNKNOWN",
+                7,
+                "a".repeat(51)
+        );
+
+        assertThat(validator.validate(request)).hasSize(3);
+    }
+
+    @Test
+    void acceptsValidRequest() {
+        UserProfileUpdateRequest request = new UserProfileUpdateRequest("SW", 3, "캠포스트유저");
+
+        assertThat(validator.validate(request)).isEmpty();
+    }
+}

--- a/src/test/java/com/campost/backend/domain/user/service/UserProfileQueryServiceTest.java
+++ b/src/test/java/com/campost/backend/domain/user/service/UserProfileQueryServiceTest.java
@@ -7,6 +7,7 @@ import com.campost.backend.domain.user.exception.UserNotFoundException;
 import com.campost.backend.domain.user.model.UserOnboardingProfile;
 import com.campost.backend.domain.user.model.UserOnboardingProfileUpdateCommand;
 import com.campost.backend.domain.user.model.UserProfile;
+import com.campost.backend.domain.user.model.UserProfileUpdateCommand;
 import org.junit.jupiter.api.Test;
 
 import java.time.OffsetDateTime;
@@ -87,6 +88,11 @@ class UserProfileQueryServiceTest {
         public Optional<UserProfile> findProfileById(long userId) {
             this.checkedUserId = userId;
             return profile;
+        }
+
+        @Override
+        public Optional<UserProfile> updateProfile(UserProfileUpdateCommand command) {
+            throw new UnsupportedOperationException("Not used in this test.");
         }
 
         @Override

--- a/src/test/java/com/campost/backend/domain/user/service/UserProfileUpdateServiceTest.java
+++ b/src/test/java/com/campost/backend/domain/user/service/UserProfileUpdateServiceTest.java
@@ -3,7 +3,7 @@ package com.campost.backend.domain.user.service;
 import com.campost.backend.domain.auth.model.SignupUserCreateCommand;
 import com.campost.backend.domain.auth.model.User;
 import com.campost.backend.domain.auth.repository.UserRepository;
-import com.campost.backend.domain.user.dto.OnboardingProfileRequest;
+import com.campost.backend.domain.user.dto.UserProfileUpdateRequest;
 import com.campost.backend.domain.user.exception.UserNotFoundException;
 import com.campost.backend.domain.user.model.UserOnboardingProfile;
 import com.campost.backend.domain.user.model.UserOnboardingProfileUpdateCommand;
@@ -11,47 +11,46 @@ import com.campost.backend.domain.user.model.UserProfile;
 import com.campost.backend.domain.user.model.UserProfileUpdateCommand;
 import org.junit.jupiter.api.Test;
 
+import java.time.OffsetDateTime;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-class UserOnboardingProfileServiceTest {
+class UserProfileUpdateServiceTest {
 
     private final FakeUserRepository userRepository = new FakeUserRepository();
-    private final UserOnboardingProfileService service = new UserOnboardingProfileService(userRepository);
+    private final UserProfileUpdateService service = new UserProfileUpdateService(userRepository);
 
     @Test
-    void saveProfileTrimsNicknameAndMarksProfileCompleted() {
-        OnboardingProfileRequest request = new OnboardingProfileRequest(
-                "SW",
-                3,
-                " 캠포스트유저 "
-        );
+    void updateProfileTrimsNicknameAndReturnsUpdatedProfile() {
+        UserProfileUpdateRequest request = new UserProfileUpdateRequest("SW", 3, " 캠포스트유저 ");
 
-        UserOnboardingProfile profile = service.saveProfile(1L, request);
+        UserProfile profile = service.updateProfile(1L, request);
 
         assertThat(userRepository.savedCommand.userId()).isEqualTo(1L);
         assertThat(userRepository.savedCommand.department()).isEqualTo("SW");
         assertThat(userRepository.savedCommand.grade()).isEqualTo(3);
         assertThat(userRepository.savedCommand.nickname()).isEqualTo("캠포스트유저");
         assertThat(profile.nickname()).isEqualTo("캠포스트유저");
+        assertThat(profile.department()).isEqualTo("SW");
+        assertThat(profile.grade()).isEqualTo(3);
         assertThat(profile.profileCompleted()).isTrue();
     }
 
     @Test
-    void saveProfileThrowsExceptionWhenUserDoesNotExist() {
+    void updateProfileThrowsExceptionWhenUserDoesNotExist() {
         userRepository.updatedProfile = Optional.empty();
-        OnboardingProfileRequest request = new OnboardingProfileRequest("SW", 2, "캠포스트유저");
+        UserProfileUpdateRequest request = new UserProfileUpdateRequest("SW", 2, "캠포스트유저");
 
-        assertThatThrownBy(() -> service.saveProfile(999L, request))
+        assertThatThrownBy(() -> service.updateProfile(999L, request))
                 .isInstanceOf(UserNotFoundException.class);
     }
 
     private static class FakeUserRepository implements UserRepository {
 
-        private UserOnboardingProfileUpdateCommand savedCommand;
-        private Optional<UserOnboardingProfile> updatedProfile;
+        private UserProfileUpdateCommand savedCommand;
+        private Optional<UserProfile> updatedProfile;
 
         @Override
         public User save(SignupUserCreateCommand command) {
@@ -80,23 +79,28 @@ class UserOnboardingProfileServiceTest {
 
         @Override
         public Optional<UserProfile> updateProfile(UserProfileUpdateCommand command) {
-            throw new UnsupportedOperationException("Not used in this test.");
-        }
-
-        @Override
-        public Optional<UserOnboardingProfile> updateOnboardingProfile(UserOnboardingProfileUpdateCommand command) {
             this.savedCommand = command;
             if (updatedProfile != null) {
                 return updatedProfile;
             }
 
-            return Optional.of(new UserOnboardingProfile(
+            return Optional.of(new UserProfile(
                     command.userId(),
+                    "campost123",
+                    "campost@example.com",
+                    command.nickname(),
                     command.department(),
                     command.grade(),
-                    command.nickname(),
-                    true
+                    "GUEST",
+                    true,
+                    OffsetDateTime.parse("2026-05-20T01:00:00Z"),
+                    OffsetDateTime.parse("2026-05-20T02:00:00Z")
             ));
+        }
+
+        @Override
+        public Optional<UserOnboardingProfile> updateOnboardingProfile(UserOnboardingProfileUpdateCommand command) {
+            throw new UnsupportedOperationException("Not used in this test.");
         }
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #49 

## 🏷️ PR 타입

- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)
- [ ] ⚙️ 프로젝트 초기 설정 (Chore)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🚨 PR 복구 (Revert)

## 📝 작업 내용

- 사용자 프로필 정보 수정 API를 추가했습니다.
  - `PATCH /api/v1/users/me/profile`
  - 수정 대상: 닉네임, 학과, 학년
- 프로필 수정 요청 DTO를 추가했습니다.
  - `UserProfileUpdateRequest`
  - 필수값 검증
  - 학과 코드 검증
  - 학년 범위 검증
  - 닉네임 길이 검증
- 프로필 수정용 service/repository 로직을 추가했습니다.
  - `UserProfileUpdateService`
  - `UserProfileUpdateCommand`
  - `UserRepository.updateProfile`
  - `JdbcUserRepository.updateProfile`
- 온보딩 프로필 저장 API와 달리, 일반 프로필 수정 API는 `profile_completed` 값을 변경하지 않도록 분리했습니다.
- 수정 성공 시 최신 사용자 프로필 정보를 `UserProfileResponse`로 반환하도록 구현했습니다.
- Swagger 문서에 프로필 수정 API가 노출되도록 controller 문서를 추가했습니다.
- 프로필 수정 요청 validation 테스트를 추가했습니다.
- 프로필 수정 service 단위 테스트를 추가했습니다.
- `UserRepository` 인터페이스 변경에 따라 기존 테스트용 Fake Repository 구현체를 보완했습니다.

## 테스트

- `./mvnw.cmd test`

## 테스트 결과

- 총 46개 테스트 통과
- Failures: 0
- Errors: 0

## 코드리뷰 반영 내용

- `JdbcUserRepository`의 `UserProfile` 매핑 중복을 제거했습니다.
  - `findProfileById`
  - `updateProfile`
  - 두 메서드가 공통 `RowMapper<UserProfile>`를 사용하도록 변경했습니다.

- `UserProfileUpdateRequest`의 닉네임 길이 검증 메시지를 개선했습니다.
  - 기존 하드코딩 `50자`
  - 변경 `{max}자`
  - `UserProfileValidationRules.MAX_NICKNAME_LENGTH` 값 변경 시 메시지도 함께 반영됩니다.

- `UserProfileUpdateService`에서 문자열 정규화 시 null 방어를 추가했습니다.
  - `department`
  - `nickname`
  - Bean Validation을 기본 전제로 유지하되, 서비스 단독 호출 시에도 null 값에 대해 명확하게 실패하도록 처리했습니다.

## 테스트

- `./mvnw.cmd test`

## 테스트 결과

- 총 46개 테스트 통과
- Failures: 0
- Errors: 0
## 📸 스크린샷

- 테스트 결과를 스크린샷으로 첨부해주세요.

## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다.
- [x] 코드 스타일 가이드를 준수했습니다.
- [x] 셀프 리뷰를 완료했습니다.
- [x] 테스트를 작성하고 모두 통과했습니다.
- [x] 문서를 업데이트했습니다. (필요한 경우)

## 📎 기타 참고사항

- 논의가 필요한 부분, 리뷰 시 유의사항 등을 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 사용자가 자신의 프로필 정보를 수정할 수 있는 기능이 추가되었습니다.
  * 부서, 학년, 닉네임을 업데이트할 수 있으며, 각 필드에 대한 유효성 검증이 적용됩니다.

* **테스트**
  * 새로운 프로필 업데이트 기능에 대한 포괄적인 테스트 케이스가 추가되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Team-CamPost/CamPost-backend/pull/50?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->