### PR TITLE
Feat(#51): 비밀번호 변경 API 구현

### DIFF
--- a/src/main/java/com/campost/backend/domain/auth/repository/JdbcUserRepository.java
+++ b/src/main/java/com/campost/backend/domain/auth/repository/JdbcUserRepository.java
@@ -28,6 +28,16 @@ public class JdbcUserRepository implements UserRepository {
             rs.getObject("last_login_at", java.time.OffsetDateTime.class)
     );
 
+    private static final RowMapper<User> USER_ROW_MAPPER = (rs, rowNum) -> new User(
+            rs.getLong("id"),
+            rs.getString("username"),
+            rs.getString("name"),
+            rs.getString("email"),
+            rs.getString("password_hash"),
+            rs.getString("role"),
+            rs.getObject("created_at", java.time.OffsetDateTime.class)
+    );
+
     private final JdbcClient jdbcClient;
 
     public JdbcUserRepository(JdbcClient jdbcClient) {
@@ -101,15 +111,21 @@ public class JdbcUserRepository implements UserRepository {
 
         return jdbcClient.sql(sql)
                 .param("username", username)
-                .query((rs, rowNum) -> new User(
-                        rs.getLong("id"),
-                        rs.getString("username"),
-                        rs.getString("name"),
-                        rs.getString("email"),
-                        rs.getString("password_hash"),
-                        rs.getString("role"),
-                        rs.getObject("created_at", java.time.OffsetDateTime.class)
-                ))
+                .query(USER_ROW_MAPPER)
+                .optional();
+    }
+
+    @Override
+    public Optional<User> findById(long userId) {
+        String sql = """
+                SELECT id, username, name, email, password_hash, role, created_at
+                FROM users
+                WHERE id = :userId
+                """;
+
+        return jdbcClient.sql(sql)
+                .param("userId", userId)
+                .query(USER_ROW_MAPPER)
                 .optional();
     }
 
@@ -147,6 +163,20 @@ public class JdbcUserRepository implements UserRepository {
                 .param("userId", command.userId())
                 .query(USER_PROFILE_ROW_MAPPER)
                 .optional();
+    }
+
+    @Override
+    public boolean updatePasswordHash(long userId, String passwordHash) {
+        String sql = """
+                UPDATE users
+                SET password_hash = :passwordHash
+                WHERE id = :userId
+                """;
+
+        return jdbcClient.sql(sql)
+                .param("passwordHash", passwordHash)
+                .param("userId", userId)
+                .update() == 1;
     }
 
     @Override

--- a/src/main/java/com/campost/backend/domain/auth/repository/JdbcUserRepository.java
+++ b/src/main/java/com/campost/backend/domain/auth/repository/JdbcUserRepository.java
@@ -57,15 +57,7 @@ public class JdbcUserRepository implements UserRepository {
                 .param("username", command.username())
                 .param("email", command.email())
                 .param("passwordHash", command.passwordHash())
-                .query((rs, rowNum) -> new User(
-                        rs.getLong("id"),
-                        rs.getString("username"),
-                        rs.getString("name"),
-                        rs.getString("email"),
-                        rs.getString("password_hash"),
-                        rs.getString("role"),
-                        rs.getObject("created_at", java.time.OffsetDateTime.class)
-                ))
+                .query(USER_ROW_MAPPER)
                 .single();
     }
 

--- a/src/main/java/com/campost/backend/domain/auth/repository/UserRepository.java
+++ b/src/main/java/com/campost/backend/domain/auth/repository/UserRepository.java
@@ -19,9 +19,13 @@ public interface UserRepository {
 
     Optional<User> findByUsername(String username);
 
+    Optional<User> findById(long userId);
+
     Optional<UserProfile> findProfileById(long userId);
 
     Optional<UserProfile> updateProfile(UserProfileUpdateCommand command);
+
+    boolean updatePasswordHash(long userId, String passwordHash);
 
     Optional<UserOnboardingProfile> updateOnboardingProfile(UserOnboardingProfileUpdateCommand command);
 }

--- a/src/main/java/com/campost/backend/domain/user/controller/UserProfileController.java
+++ b/src/main/java/com/campost/backend/domain/user/controller/UserProfileController.java
@@ -2,9 +2,11 @@ package com.campost.backend.domain.user.controller;
 
 import com.campost.backend.domain.user.dto.OnboardingProfileRequest;
 import com.campost.backend.domain.user.dto.OnboardingProfileResponse;
+import com.campost.backend.domain.user.dto.UserPasswordChangeRequest;
 import com.campost.backend.domain.user.dto.UserProfileResponse;
 import com.campost.backend.domain.user.dto.UserProfileUpdateRequest;
 import com.campost.backend.domain.user.service.UserOnboardingProfileService;
+import com.campost.backend.domain.user.service.UserPasswordChangeService;
 import com.campost.backend.domain.user.service.UserProfileQueryService;
 import com.campost.backend.domain.user.service.UserProfileUpdateService;
 import com.campost.backend.global.api.ApiResponse;
@@ -34,20 +36,60 @@ public class UserProfileController {
     private static final String BEARER_PREFIX = "Bearer ";
 
     private final UserOnboardingProfileService userOnboardingProfileService;
+    private final UserPasswordChangeService userPasswordChangeService;
     private final UserProfileQueryService userProfileQueryService;
     private final UserProfileUpdateService userProfileUpdateService;
     private final JwtTokenService jwtTokenService;
 
     public UserProfileController(
             UserOnboardingProfileService userOnboardingProfileService,
+            UserPasswordChangeService userPasswordChangeService,
             UserProfileQueryService userProfileQueryService,
             UserProfileUpdateService userProfileUpdateService,
             JwtTokenService jwtTokenService
     ) {
         this.userOnboardingProfileService = userOnboardingProfileService;
+        this.userPasswordChangeService = userPasswordChangeService;
         this.userProfileQueryService = userProfileQueryService;
         this.userProfileUpdateService = userProfileUpdateService;
         this.jwtTokenService = jwtTokenService;
+    }
+
+    @Operation(
+            summary = "비밀번호 변경",
+            description = "로그인한 사용자의 현재 비밀번호를 확인한 뒤 새 비밀번호로 변경합니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "비밀번호 변경 성공"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "입력값 검증 실패",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패 또는 현재 비밀번호 불일치",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "사용자를 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+    @PatchMapping("/me/password")
+    public ApiResponse<Void> changePassword(
+            @RequestHeader(name = "Authorization", required = false) String authorization,
+            @Valid @RequestBody UserPasswordChangeRequest request
+    ) {
+        long userId = resolveUserId(authorization);
+        userPasswordChangeService.changePassword(userId, request);
+
+        return ApiResponse.ok(null);
     }
 
     @Operation(

--- a/src/main/java/com/campost/backend/domain/user/dto/UserPasswordChangeRequest.java
+++ b/src/main/java/com/campost/backend/domain/user/dto/UserPasswordChangeRequest.java
@@ -1,0 +1,22 @@
+package com.campost.backend.domain.user.dto;
+
+import com.campost.backend.domain.auth.validation.AuthValidationRules;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+@Schema(description = "사용자 비밀번호 변경 요청")
+public record UserPasswordChangeRequest(
+        @Schema(description = "현재 비밀번호", example = "password123")
+        @NotBlank(message = "현재 비밀번호를 입력해주세요.")
+        String currentPassword,
+
+        @Schema(description = "새 비밀번호", example = "newPassword123")
+        @NotBlank(message = "새 비밀번호를 입력해주세요.")
+        @Pattern(
+                regexp = AuthValidationRules.PASSWORD_PATTERN,
+                message = AuthValidationRules.PASSWORD_MESSAGE
+        )
+        String newPassword
+) {
+}

--- a/src/main/java/com/campost/backend/domain/user/exception/SamePasswordException.java
+++ b/src/main/java/com/campost/backend/domain/user/exception/SamePasswordException.java
@@ -1,0 +1,8 @@
+package com.campost.backend.domain.user.exception;
+
+public class SamePasswordException extends RuntimeException {
+
+    public SamePasswordException() {
+        super("New password must be different from the current password.");
+    }
+}

--- a/src/main/java/com/campost/backend/domain/user/service/UserPasswordChangeService.java
+++ b/src/main/java/com/campost/backend/domain/user/service/UserPasswordChangeService.java
@@ -5,6 +5,7 @@ import com.campost.backend.domain.auth.model.User;
 import com.campost.backend.domain.auth.repository.UserRepository;
 import com.campost.backend.domain.auth.service.PasswordHashService;
 import com.campost.backend.domain.user.dto.UserPasswordChangeRequest;
+import com.campost.backend.domain.user.exception.SamePasswordException;
 import com.campost.backend.domain.user.exception.UserNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,6 +31,10 @@ public class UserPasswordChangeService {
 
         if (!passwordHashService.matches(request.currentPassword(), user.passwordHash())) {
             throw new BadCredentialsException();
+        }
+
+        if (request.currentPassword().equals(request.newPassword())) {
+            throw new SamePasswordException();
         }
 
         String newPasswordHash = passwordHashService.hash(request.newPassword());

--- a/src/main/java/com/campost/backend/domain/user/service/UserPasswordChangeService.java
+++ b/src/main/java/com/campost/backend/domain/user/service/UserPasswordChangeService.java
@@ -1,0 +1,42 @@
+package com.campost.backend.domain.user.service;
+
+import com.campost.backend.domain.auth.exception.BadCredentialsException;
+import com.campost.backend.domain.auth.model.User;
+import com.campost.backend.domain.auth.repository.UserRepository;
+import com.campost.backend.domain.auth.service.PasswordHashService;
+import com.campost.backend.domain.user.dto.UserPasswordChangeRequest;
+import com.campost.backend.domain.user.exception.UserNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class UserPasswordChangeService {
+
+    private final UserRepository userRepository;
+    private final PasswordHashService passwordHashService;
+
+    public UserPasswordChangeService(
+            UserRepository userRepository,
+            PasswordHashService passwordHashService
+    ) {
+        this.userRepository = userRepository;
+        this.passwordHashService = passwordHashService;
+    }
+
+    @Transactional
+    public void changePassword(long userId, UserPasswordChangeRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
+
+        if (!passwordHashService.matches(request.currentPassword(), user.passwordHash())) {
+            throw new BadCredentialsException();
+        }
+
+        String newPasswordHash = passwordHashService.hash(request.newPassword());
+        boolean updated = userRepository.updatePasswordHash(userId, newPasswordHash);
+
+        if (!updated) {
+            throw new UserNotFoundException();
+        }
+    }
+}

--- a/src/main/java/com/campost/backend/global/api/ApiCode.java
+++ b/src/main/java/com/campost/backend/global/api/ApiCode.java
@@ -7,6 +7,7 @@ public enum ApiCode {
     AUTH200_LOGIN(HttpStatus.OK, "AUTH200", "로그인에 성공했습니다."),
     AUTH201(HttpStatus.CREATED, "AUTH201", "회원가입 요청 형식 검증에 성공했습니다."),
     AUTH401_CREDENTIALS(HttpStatus.UNAUTHORIZED, "AUTH401_CREDENTIALS", "아이디 또는 비밀번호가 올바르지 않습니다."),
+    USER400_SAME_PASSWORD(HttpStatus.BAD_REQUEST, "USER400_SAME_PASSWORD", "새 비밀번호는 현재 비밀번호와 달라야 합니다."),
     AUTH400_EMAIL_VERIFICATION(HttpStatus.BAD_REQUEST, "AUTH400_EMAIL_VERIFICATION", "이메일 인증번호가 유효하지 않습니다."),
     AUTH503_EMAIL_VERIFICATION_SEND(HttpStatus.SERVICE_UNAVAILABLE, "AUTH503_EMAIL_VERIFICATION_SEND", "이메일 인증번호 발송에 실패했습니다."),
     AUTH409(HttpStatus.CONFLICT, "AUTH409", "이미 가입된 이메일입니다."),

--- a/src/main/java/com/campost/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/campost/backend/global/exception/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import com.campost.backend.domain.auth.exception.DuplicatedUsernameException;
 import com.campost.backend.domain.auth.exception.EmailVerificationSendException;
 import com.campost.backend.domain.auth.exception.InvalidEmailVerificationCodeException;
 import com.campost.backend.domain.auth.exception.UnverifiedEmailException;
+import com.campost.backend.domain.user.exception.SamePasswordException;
 import com.campost.backend.domain.user.exception.UserNotFoundException;
 import com.campost.backend.global.api.ApiCode;
 import com.campost.backend.global.api.ErrorResponse;
@@ -74,6 +75,11 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(UserNotFoundException.class)
     public ResponseEntity<ErrorResponse> handleUserNotFound(UserNotFoundException ex) {
         return toResponse(ApiCode.COMMON404);
+    }
+
+    @ExceptionHandler(SamePasswordException.class)
+    public ResponseEntity<ErrorResponse> handleSamePassword(SamePasswordException ex) {
+        return toResponse(ApiCode.USER400_SAME_PASSWORD);
     }
 
     @ExceptionHandler(DataIntegrityViolationException.class)

--- a/src/test/java/com/campost/backend/domain/auth/service/EmailVerificationServiceTest.java
+++ b/src/test/java/com/campost/backend/domain/auth/service/EmailVerificationServiceTest.java
@@ -187,12 +187,22 @@ class EmailVerificationServiceTest {
         }
 
         @Override
+        public Optional<User> findById(long userId) {
+            throw new UnsupportedOperationException("Not used in this test.");
+        }
+
+        @Override
         public Optional<UserProfile> findProfileById(long userId) {
             throw new UnsupportedOperationException("Not used in this test.");
         }
 
         @Override
         public Optional<UserProfile> updateProfile(UserProfileUpdateCommand command) {
+            throw new UnsupportedOperationException("Not used in this test.");
+        }
+
+        @Override
+        public boolean updatePasswordHash(long userId, String passwordHash) {
             throw new UnsupportedOperationException("Not used in this test.");
         }
 

--- a/src/test/java/com/campost/backend/domain/auth/service/LoginServiceTest.java
+++ b/src/test/java/com/campost/backend/domain/auth/service/LoginServiceTest.java
@@ -87,12 +87,22 @@ class LoginServiceTest {
         }
 
         @Override
+        public Optional<User> findById(long userId) {
+            throw new UnsupportedOperationException("Not used in this test.");
+        }
+
+        @Override
         public Optional<UserProfile> findProfileById(long userId) {
             throw new UnsupportedOperationException("Not used in this test.");
         }
 
         @Override
         public Optional<UserProfile> updateProfile(UserProfileUpdateCommand command) {
+            throw new UnsupportedOperationException("Not used in this test.");
+        }
+
+        @Override
+        public boolean updatePasswordHash(long userId, String passwordHash) {
             throw new UnsupportedOperationException("Not used in this test.");
         }
 

--- a/src/test/java/com/campost/backend/domain/auth/service/SignupUserServiceTest.java
+++ b/src/test/java/com/campost/backend/domain/auth/service/SignupUserServiceTest.java
@@ -223,12 +223,22 @@ class SignupUserServiceTest {
         }
 
         @Override
+        public Optional<User> findById(long userId) {
+            throw new UnsupportedOperationException("Not used in this test.");
+        }
+
+        @Override
         public Optional<UserProfile> findProfileById(long userId) {
             throw new UnsupportedOperationException("Not used in this test.");
         }
 
         @Override
         public Optional<UserProfile> updateProfile(UserProfileUpdateCommand command) {
+            throw new UnsupportedOperationException("Not used in this test.");
+        }
+
+        @Override
+        public boolean updatePasswordHash(long userId, String passwordHash) {
             throw new UnsupportedOperationException("Not used in this test.");
         }
 

--- a/src/test/java/com/campost/backend/domain/user/dto/UserPasswordChangeRequestValidationTest.java
+++ b/src/test/java/com/campost/backend/domain/user/dto/UserPasswordChangeRequestValidationTest.java
@@ -1,0 +1,40 @@
+package com.campost.backend.domain.user.dto;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UserPasswordChangeRequestValidationTest {
+
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+    @Test
+    void validatesRequiredFields() {
+        UserPasswordChangeRequest request = new UserPasswordChangeRequest("", "");
+
+        assertThat(validator.validate(request)).hasSizeGreaterThanOrEqualTo(2);
+    }
+
+    @Test
+    void validatesNewPasswordRules() {
+        UserPasswordChangeRequest request = new UserPasswordChangeRequest(
+                "password123",
+                "password"
+        );
+
+        assertThat(validator.validate(request))
+                .anyMatch(violation -> violation.getPropertyPath().toString().equals("newPassword"));
+    }
+
+    @Test
+    void acceptsValidRequest() {
+        UserPasswordChangeRequest request = new UserPasswordChangeRequest(
+                "password123",
+                "newPassword123"
+        );
+
+        assertThat(validator.validate(request)).isEmpty();
+    }
+}

--- a/src/test/java/com/campost/backend/domain/user/service/UserOnboardingProfileServiceTest.java
+++ b/src/test/java/com/campost/backend/domain/user/service/UserOnboardingProfileServiceTest.java
@@ -74,12 +74,22 @@ class UserOnboardingProfileServiceTest {
         }
 
         @Override
+        public Optional<User> findById(long userId) {
+            throw new UnsupportedOperationException("Not used in this test.");
+        }
+
+        @Override
         public Optional<UserProfile> findProfileById(long userId) {
             throw new UnsupportedOperationException("Not used in this test.");
         }
 
         @Override
         public Optional<UserProfile> updateProfile(UserProfileUpdateCommand command) {
+            throw new UnsupportedOperationException("Not used in this test.");
+        }
+
+        @Override
+        public boolean updatePasswordHash(long userId, String passwordHash) {
             throw new UnsupportedOperationException("Not used in this test.");
         }
 

--- a/src/test/java/com/campost/backend/domain/user/service/UserPasswordChangeServiceTest.java
+++ b/src/test/java/com/campost/backend/domain/user/service/UserPasswordChangeServiceTest.java
@@ -1,0 +1,145 @@
+package com.campost.backend.domain.user.service;
+
+import com.campost.backend.domain.auth.exception.BadCredentialsException;
+import com.campost.backend.domain.auth.model.SignupUserCreateCommand;
+import com.campost.backend.domain.auth.model.User;
+import com.campost.backend.domain.auth.repository.UserRepository;
+import com.campost.backend.domain.auth.service.PasswordHashService;
+import com.campost.backend.domain.user.dto.UserPasswordChangeRequest;
+import com.campost.backend.domain.user.exception.UserNotFoundException;
+import com.campost.backend.domain.user.model.UserOnboardingProfile;
+import com.campost.backend.domain.user.model.UserOnboardingProfileUpdateCommand;
+import com.campost.backend.domain.user.model.UserProfile;
+import com.campost.backend.domain.user.model.UserProfileUpdateCommand;
+import org.junit.jupiter.api.Test;
+
+import java.time.OffsetDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class UserPasswordChangeServiceTest {
+
+    private final FakeUserRepository userRepository = new FakeUserRepository();
+    private final PasswordHashService passwordHashService = new PasswordHashService();
+    private final UserPasswordChangeService service = new UserPasswordChangeService(
+            userRepository,
+            passwordHashService
+    );
+
+    @Test
+    void changePasswordVerifiesCurrentPasswordAndStoresHashedNewPassword() {
+        userRepository.user = Optional.of(userWithPasswordHash(passwordHashService.hash("password123")));
+
+        service.changePassword(1L, new UserPasswordChangeRequest("password123", "newPassword123"));
+
+        assertThat(userRepository.checkedUserId).isEqualTo(1L);
+        assertThat(userRepository.updatedUserId).isEqualTo(1L);
+        assertThat(userRepository.updatedPasswordHash).isNotEqualTo("newPassword123");
+        assertThat(userRepository.updatedPasswordHash).doesNotContain("newPassword123");
+        assertThat(passwordHashService.matches("newPassword123", userRepository.updatedPasswordHash)).isTrue();
+    }
+
+    @Test
+    void changePasswordThrowsExceptionWhenCurrentPasswordDoesNotMatch() {
+        userRepository.user = Optional.of(userWithPasswordHash(passwordHashService.hash("password123")));
+
+        assertThatThrownBy(() -> service.changePassword(
+                1L,
+                new UserPasswordChangeRequest("wrongPassword123", "newPassword123")
+        )).isInstanceOf(BadCredentialsException.class);
+
+        assertThat(userRepository.updatedPasswordHash).isNull();
+    }
+
+    @Test
+    void changePasswordThrowsExceptionWhenUserDoesNotExist() {
+        userRepository.user = Optional.empty();
+
+        assertThatThrownBy(() -> service.changePassword(
+                999L,
+                new UserPasswordChangeRequest("password123", "newPassword123")
+        )).isInstanceOf(UserNotFoundException.class);
+    }
+
+    @Test
+    void changePasswordThrowsExceptionWhenUpdateFails() {
+        userRepository.user = Optional.of(userWithPasswordHash(passwordHashService.hash("password123")));
+        userRepository.updateResult = false;
+
+        assertThatThrownBy(() -> service.changePassword(
+                1L,
+                new UserPasswordChangeRequest("password123", "newPassword123")
+        )).isInstanceOf(UserNotFoundException.class);
+    }
+
+    private User userWithPasswordHash(String passwordHash) {
+        return new User(
+                1L,
+                "campost123",
+                "CamPost User",
+                "campost@example.com",
+                passwordHash,
+                "GUEST",
+                OffsetDateTime.parse("2026-05-20T01:00:00Z")
+        );
+    }
+
+    private static class FakeUserRepository implements UserRepository {
+
+        private Optional<User> user = Optional.empty();
+        private long checkedUserId;
+        private long updatedUserId;
+        private String updatedPasswordHash;
+        private boolean updateResult = true;
+
+        @Override
+        public User save(SignupUserCreateCommand command) {
+            throw new UnsupportedOperationException("Not used in this test.");
+        }
+
+        @Override
+        public boolean existsByEmail(String email) {
+            throw new UnsupportedOperationException("Not used in this test.");
+        }
+
+        @Override
+        public boolean existsByUsername(String username) {
+            throw new UnsupportedOperationException("Not used in this test.");
+        }
+
+        @Override
+        public Optional<User> findByUsername(String username) {
+            throw new UnsupportedOperationException("Not used in this test.");
+        }
+
+        @Override
+        public Optional<User> findById(long userId) {
+            this.checkedUserId = userId;
+            return user;
+        }
+
+        @Override
+        public Optional<UserProfile> findProfileById(long userId) {
+            throw new UnsupportedOperationException("Not used in this test.");
+        }
+
+        @Override
+        public Optional<UserProfile> updateProfile(UserProfileUpdateCommand command) {
+            throw new UnsupportedOperationException("Not used in this test.");
+        }
+
+        @Override
+        public boolean updatePasswordHash(long userId, String passwordHash) {
+            this.updatedUserId = userId;
+            this.updatedPasswordHash = passwordHash;
+            return updateResult;
+        }
+
+        @Override
+        public Optional<UserOnboardingProfile> updateOnboardingProfile(UserOnboardingProfileUpdateCommand command) {
+            throw new UnsupportedOperationException("Not used in this test.");
+        }
+    }
+}

--- a/src/test/java/com/campost/backend/domain/user/service/UserPasswordChangeServiceTest.java
+++ b/src/test/java/com/campost/backend/domain/user/service/UserPasswordChangeServiceTest.java
@@ -6,6 +6,7 @@ import com.campost.backend.domain.auth.model.User;
 import com.campost.backend.domain.auth.repository.UserRepository;
 import com.campost.backend.domain.auth.service.PasswordHashService;
 import com.campost.backend.domain.user.dto.UserPasswordChangeRequest;
+import com.campost.backend.domain.user.exception.SamePasswordException;
 import com.campost.backend.domain.user.exception.UserNotFoundException;
 import com.campost.backend.domain.user.model.UserOnboardingProfile;
 import com.campost.backend.domain.user.model.UserOnboardingProfileUpdateCommand;
@@ -49,6 +50,18 @@ class UserPasswordChangeServiceTest {
                 1L,
                 new UserPasswordChangeRequest("wrongPassword123", "newPassword123")
         )).isInstanceOf(BadCredentialsException.class);
+
+        assertThat(userRepository.updatedPasswordHash).isNull();
+    }
+
+    @Test
+    void changePasswordRejectsSamePasswordWithoutUpdating() {
+        userRepository.user = Optional.of(userWithPasswordHash(passwordHashService.hash("password123")));
+
+        assertThatThrownBy(() -> service.changePassword(
+                1L,
+                new UserPasswordChangeRequest("password123", "password123")
+        )).isInstanceOf(SamePasswordException.class);
 
         assertThat(userRepository.updatedPasswordHash).isNull();
     }

--- a/src/test/java/com/campost/backend/domain/user/service/UserProfileQueryServiceTest.java
+++ b/src/test/java/com/campost/backend/domain/user/service/UserProfileQueryServiceTest.java
@@ -85,6 +85,11 @@ class UserProfileQueryServiceTest {
         }
 
         @Override
+        public Optional<User> findById(long userId) {
+            throw new UnsupportedOperationException("Not used in this test.");
+        }
+
+        @Override
         public Optional<UserProfile> findProfileById(long userId) {
             this.checkedUserId = userId;
             return profile;
@@ -92,6 +97,11 @@ class UserProfileQueryServiceTest {
 
         @Override
         public Optional<UserProfile> updateProfile(UserProfileUpdateCommand command) {
+            throw new UnsupportedOperationException("Not used in this test.");
+        }
+
+        @Override
+        public boolean updatePasswordHash(long userId, String passwordHash) {
             throw new UnsupportedOperationException("Not used in this test.");
         }
 

--- a/src/test/java/com/campost/backend/domain/user/service/UserProfileUpdateServiceTest.java
+++ b/src/test/java/com/campost/backend/domain/user/service/UserProfileUpdateServiceTest.java
@@ -73,6 +73,11 @@ class UserProfileUpdateServiceTest {
         }
 
         @Override
+        public Optional<User> findById(long userId) {
+            throw new UnsupportedOperationException("Not used in this test.");
+        }
+
+        @Override
         public Optional<UserProfile> findProfileById(long userId) {
             throw new UnsupportedOperationException("Not used in this test.");
         }
@@ -96,6 +101,11 @@ class UserProfileUpdateServiceTest {
                     OffsetDateTime.parse("2026-05-20T01:00:00Z"),
                     OffsetDateTime.parse("2026-05-20T02:00:00Z")
             ));
+        }
+
+        @Override
+        public boolean updatePasswordHash(long userId, String passwordHash) {
+            throw new UnsupportedOperationException("Not used in this test.");
         }
 
         @Override


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #51 

## 🏷️ PR 타입

- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)
- [ ] ⚙️ 프로젝트 초기 설정 (Chore)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🚨 PR 복구 (Revert)

## 📝 작업 내용

- 비밀번호 변경 API를 추가했습니다.
  - `PATCH /api/v1/users/me/password`
  - 로그인한 사용자의 현재 비밀번호를 확인한 뒤 새 비밀번호로 변경합니다.

- 비밀번호 변경 요청 DTO를 추가했습니다.
  - `UserPasswordChangeRequest`
  - `currentPassword`
  - `newPassword`
  - 새 비밀번호는 기존 회원가입 비밀번호 정책을 재사용합니다.
    - 영문 + 숫자 포함
    - 8자 이상

- 비밀번호 변경 서비스 로직을 추가했습니다.
  - 현재 비밀번호 검증
  - 새 비밀번호 단방향 해시 처리
  - 해시된 새 비밀번호 저장
  - 현재 비밀번호 불일치 시 `BadCredentialsException` 발생
  - 사용자 미존재 또는 저장 실패 시 `UserNotFoundException` 발생

- 사용자 조회/비밀번호 저장 repository 메서드를 추가했습니다.
  - `findById`
  - `updatePasswordHash`

- `JdbcUserRepository`의 `User` 매핑 로직을 `USER_ROW_MAPPER`로 분리했습니다.
  - `findByUsername`
  - `findById`
  - 두 메서드에서 공통 사용

- Swagger 문서에 비밀번호 변경 API가 반영되도록 controller 문서를 추가했습니다.

- 테스트를 추가했습니다.
  - 비밀번호 변경 요청 validation 테스트
  - 비밀번호 변경 service 단위 테스트
  - 현재 비밀번호 검증
  - 새 비밀번호 해시 저장 검증
  - 현재 비밀번호 불일치 검증
  - 사용자 미존재/업데이트 실패 검증

- `UserRepository` 인터페이스 변경에 따라 기존 테스트용 Fake Repository 구현체를 보완했습니다.

## 테스트

- `./mvnw.cmd test`

## 테스트 결과

- 총 53개 테스트 통과
- Failures: 0
- Errors: 0

## 코드리뷰 반영 내용

- 현재 비밀번호와 새 비밀번호가 동일한 경우 변경을 차단하도록 추가했습니다.
  - `SamePasswordException` 추가
  - `USER400_SAME_PASSWORD` 응답 코드 추가
  - `GlobalExceptionHandler`에서 400 Bad Request로 매핑
  - 현재 비밀번호 검증은 먼저 수행하고, 검증 통과 후 동일 비밀번호 여부를 확인합니다.

- 동일 비밀번호 요청 시 불필요한 새 비밀번호 해싱 및 DB 업데이트가 발생하지 않도록 처리했습니다.

- `JdbcUserRepository.save()`의 인라인 `User` 매핑 로직을 제거하고 기존 `USER_ROW_MAPPER`를 재사용하도록 변경했습니다.

- 동일 비밀번호 변경 차단 단위 테스트를 추가했습니다.
  - `SamePasswordException` 발생 검증
  - DB 업데이트 미수행 검증

## 테스트

- `./mvnw.cmd test`

## 테스트 결과

- 총 54개 테스트 통과
- Failures: 0
- Errors: 0

## 📸 스크린샷

- 테스트 결과를 스크린샷으로 첨부해주세요.

## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다.
- [x] 코드 스타일 가이드를 준수했습니다.
- [x] 셀프 리뷰를 완료했습니다.
- [x] 테스트를 작성하고 모두 통과했습니다.
- [ ] 문서를 업데이트했습니다. (필요한 경우)

## 📎 기타 참고사항

- 논의가 필요한 부분, 리뷰 시 유의사항 등을 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 출시 노트

* **새로운 기능**
  * 사용자가 현재 비밀번호를 검증한 후 새로운 비밀번호로 변경할 수 있는 기능이 추가되었습니다. 비밀번호 변경 시 필수 입력 검증 및 형식 규칙 검증이 적용됩니다.

* **테스트**
  * 비밀번호 변경 기능에 대한 유효성 검사 및 통합 테스트가 추가되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Team-CamPost/CamPost-backend/pull/52?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->