### PR TITLE
Feat(#55): 파이프라인 렌더링 파일 API 연동

### DIFF
--- a/src/main/java/com/campost/backend/domain/post/notice/dto/NoticeDetailDto.java
+++ b/src/main/java/com/campost/backend/domain/post/notice/dto/NoticeDetailDto.java
@@ -3,9 +3,12 @@ package com.campost.backend.domain.post.notice.dto;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.JsonNode;
 
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.time.OffsetDateTime;
+import java.util.List;
 
 @JsonInclude(JsonInclude.Include.ALWAYS)
 @JsonPropertyOrder({
@@ -18,9 +21,16 @@ import java.time.OffsetDateTime;
         "date",
         "views",
         "deadline",
+        "deadlineTime",
+        "deadlineAt",
         "target",
         "applyMethod",
         "bodyText",
+        "bodyHtml",
+        "contentHtml",
+        "contentAssets",
+        "contentStats",
+        "attachments",
         "sourceUrl",
         "publishedAt",
         "createdAt"
@@ -44,12 +54,26 @@ public record NoticeDetailDto(
         Integer views,
         @JsonProperty("deadline")
         LocalDate deadline,
+        @JsonProperty("deadlineTime")
+        LocalTime deadlineTime,
+        @JsonProperty("deadlineAt")
+        OffsetDateTime deadlineAt,
         @JsonProperty("target")
         String target,
         @JsonProperty("applyMethod")
         String applyMethod,
         @JsonProperty("bodyText")
         String bodyText,
+        @JsonProperty("bodyHtml")
+        String bodyHtml,
+        @JsonProperty("contentHtml")
+        String contentHtml,
+        @JsonProperty("contentAssets")
+        JsonNode contentAssets,
+        @JsonProperty("contentStats")
+        JsonNode contentStats,
+        @JsonProperty("attachments")
+        List<AttachmentDto> attachments,
         @JsonProperty("sourceUrl")
         String sourceUrl,
         @JsonProperty("publishedAt")
@@ -57,4 +81,64 @@ public record NoticeDetailDto(
         @JsonProperty("createdAt")
         OffsetDateTime createdAt
 ) {
+    @JsonInclude(JsonInclude.Include.ALWAYS)
+    @JsonPropertyOrder({
+            "id",
+            "fileKey",
+            "originalName",
+            "ext",
+            "fileType",
+            "mimeType",
+            "fileSize",
+            "checksum",
+            "sourceUrl",
+            "localPath",
+            "downloadOk",
+            "extractedText",
+            "extractedChars",
+            "parser",
+            "parseQuality",
+            "parseOk",
+            "downloadCached",
+            "createdAt"
+    })
+    public record AttachmentDto(
+            @JsonProperty("id")
+            long id,
+            @JsonProperty("fileKey")
+            String fileKey,
+            @JsonProperty("originalName")
+            String originalName,
+            @JsonProperty("ext")
+            String ext,
+            @JsonProperty("fileType")
+            String fileType,
+            @JsonProperty("mimeType")
+            String mimeType,
+            @JsonProperty("fileSize")
+            Long fileSize,
+            @JsonProperty("checksum")
+            String checksum,
+            @JsonProperty("sourceUrl")
+            String sourceUrl,
+            @JsonProperty("localPath")
+            String localPath,
+            @JsonProperty("downloadOk")
+            Boolean downloadOk,
+            @JsonProperty("extractedText")
+            String extractedText,
+            @JsonProperty("extractedChars")
+            Integer extractedChars,
+            @JsonProperty("parser")
+            String parser,
+            @JsonProperty("parseQuality")
+            String parseQuality,
+            @JsonProperty("parseOk")
+            Boolean parseOk,
+            @JsonProperty("downloadCached")
+            Boolean downloadCached,
+            @JsonProperty("createdAt")
+            OffsetDateTime createdAt
+    ) {
+    }
 }

--- a/src/main/java/com/campost/backend/domain/post/notice/repository/NoticeQueryRepository.java
+++ b/src/main/java/com/campost/backend/domain/post/notice/repository/NoticeQueryRepository.java
@@ -1,7 +1,11 @@
 package com.campost.backend.domain.post.notice.repository;
 
+import com.campost.backend.domain.post.notice.dto.NoticeDetailDto.AttachmentDto;
 import com.campost.backend.domain.post.notice.dto.NoticeDetailDto;
 import com.campost.backend.domain.post.notice.dto.NoticeDto;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.jdbc.core.simple.JdbcClient;
 import org.springframework.stereotype.Repository;
 
@@ -12,9 +16,11 @@ import java.util.Optional;
 public class NoticeQueryRepository {
 
     private final JdbcClient jdbcClient;
+    private final ObjectMapper objectMapper;
 
-    public NoticeQueryRepository(JdbcClient jdbcClient) {
+    public NoticeQueryRepository(JdbcClient jdbcClient, ObjectMapper objectMapper) {
         this.jdbcClient = jdbcClient;
+        this.objectMapper = objectMapper;
     }
 
     public List<NoticeDto> findNotices(int limit, String deptCode, String sortBy) {
@@ -73,7 +79,11 @@ public class NoticeQueryRepository {
     public Optional<NoticeDetailDto> findNoticeDetailById(long noticeId) {
         String sql = """
                 SELECT n.id, n.article_id, n.title, cs.department, n.author, n.category, n.date, n.views,
-                       n.deadline, n.target, n.apply_method, n.body_text, n.source_url, n.published_at, n.created_at
+                       n.deadline, n.deadline_time, n.deadline_at,
+                       n.target, n.apply_method, n.body_text, n.body_html,
+                       n.content_html, n.content_assets::text AS content_assets,
+                       n.content_stats::text AS content_stats,
+                       n.source_url, n.published_at, n.created_at
                 FROM notices n
               LEFT JOIN raw_notices rn ON n.raw_notice_id = rn.id
               LEFT JOIN crawl_sources cs ON rn.source_id = cs.id
@@ -92,13 +102,66 @@ public class NoticeQueryRepository {
                         rs.getObject("date", java.time.LocalDate.class),
                         rs.getObject("views", Integer.class),
                         rs.getObject("deadline", java.time.LocalDate.class),
+                        rs.getObject("deadline_time", java.time.LocalTime.class),
+                        rs.getObject("deadline_at", java.time.OffsetDateTime.class),
                         rs.getString("target"),
                         rs.getString("apply_method"),
                         rs.getString("body_text"),
+                        rs.getString("body_html"),
+                        rs.getString("content_html"),
+                        readJson(rs.getString("content_assets")),
+                        readJson(rs.getString("content_stats")),
+                        findAttachmentsByNoticeId(noticeId),
                         rs.getString("source_url"),
                         rs.getObject("published_at", java.time.OffsetDateTime.class),
                         rs.getObject("created_at", java.time.OffsetDateTime.class)
                 ))
                 .optional();
+    }
+
+    private List<AttachmentDto> findAttachmentsByNoticeId(long noticeId) {
+        String sql = """
+                SELECT id, file_key, original_name, ext, file_type, mime_type, file_size,
+                       checksum, source_url, local_path, download_ok, extracted_text,
+                       extracted_chars, parser, parse_quality, parse_ok, download_cached, created_at
+                FROM notice_attachments
+                WHERE notice_id = :noticeId
+                ORDER BY id ASC
+                """;
+
+        return jdbcClient.sql(sql)
+                .param("noticeId", noticeId)
+                .query((rs, rowNum) -> new AttachmentDto(
+                        rs.getLong("id"),
+                        rs.getString("file_key"),
+                        rs.getString("original_name"),
+                        rs.getString("ext"),
+                        rs.getString("file_type"),
+                        rs.getString("mime_type"),
+                        rs.getObject("file_size", Long.class),
+                        rs.getString("checksum"),
+                        rs.getString("source_url"),
+                        rs.getString("local_path"),
+                        rs.getObject("download_ok", Boolean.class),
+                        rs.getString("extracted_text"),
+                        rs.getObject("extracted_chars", Integer.class),
+                        rs.getString("parser"),
+                        rs.getString("parse_quality"),
+                        rs.getObject("parse_ok", Boolean.class),
+                        rs.getObject("download_cached", Boolean.class),
+                        rs.getObject("created_at", java.time.OffsetDateTime.class)
+                ))
+                .list();
+    }
+
+    private JsonNode readJson(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        try {
+            return objectMapper.readTree(value);
+        } catch (JsonProcessingException ex) {
+            throw new IllegalStateException("Failed to read notice JSON content.", ex);
+        }
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #55 

## 🏷️ PR 타입

- [ ] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)
- [ ] ⚙️ 프로젝트 초기 설정 (Chore)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🚨 PR 복구 (Revert)

## 📝 작업 내용

변경 파일:

  - Desktop/CAMPOST/CamPost-backend/src/main/java/com/campost/backend/domain/post/notice/dto/NoticeDetailDto.java
  - Desktop/CAMPOST/CamPost-backend/src/main/java/com/campost/backend/domain/post/notice/repository/
    NoticeQueryRepository.java

  구현 내용:

  - 공지 상세 응답에 아래 필드 추가
      - deadlineTime
      - deadlineAt
      - bodyHtml
      - contentHtml
      - contentAssets
      - contentStats
      - attachments
  - content_assets, content_stats는 DB의 jsonb 값을 JsonNode로 파싱해서 그대로 JSON 응답에 포함
  - notice_attachments를 조회해서 상세 응답의 attachments 배열로 반환
  - 첨부파일 응답에는 fileKey, originalName, ext, fileType, mimeType, fileSize, checksum, sourceUrl, localPath,
    downloadOk, extractedText, extractedChars, parser, parseQuality, parseOk, downloadCached 포함

  검증:

  - mvn -DskipTests compile 통과
  - mvn test 통과

## 📸 스크린샷

- 테스트 결과를 스크린샷으로 첨부해주세요.

## ✅ 체크리스트

- [ ] 코드 리뷰를 받을 준비가 완료되었습니다.
- [ ] 코드 스타일 가이드를 준수했습니다.
- [ ] 셀프 리뷰를 완료했습니다.
- [ ] 테스트를 작성하고 모두 통과했습니다.
- [ ] 문서를 업데이트했습니다. (필요한 경우)

## 📎 기타 참고사항

- 논의가 필요한 부분, 리뷰 시 유의사항 등을 작성해주세요.
