### PR TITLE
Feat(#59): 백엔드 PDF previewAPI

### DIFF
--- a/src/main/java/com/campost/backend/domain/collect/importer/model/RawNoticePayload.java
+++ b/src/main/java/com/campost/backend/domain/collect/importer/model/RawNoticePayload.java
@@ -50,7 +50,13 @@ public record RawNoticePayload(
             @JsonProperty("parser") String parser,
             @JsonProperty("parse_quality") String parseQuality,
             @JsonProperty("parse_ok") Boolean parseOk,
-            @JsonProperty("download_cached") Boolean downloadCached
+            @JsonProperty("download_cached") Boolean downloadCached,
+            @JsonProperty("preview_pdf_path") String previewPdfPath,
+            @JsonProperty("preview_pdf_size") Long previewPdfSize,
+            @JsonProperty("preview_pdf_checksum") String previewPdfChecksum,
+            @JsonProperty("conversion_status") String conversionStatus,
+            @JsonProperty("conversion_engine") String conversionEngine,
+            @JsonProperty("conversion_error") String conversionError
     ) {
     }
 }

--- a/src/main/java/com/campost/backend/domain/collect/importer/repository/RawImporterRepository.java
+++ b/src/main/java/com/campost/backend/domain/collect/importer/repository/RawImporterRepository.java
@@ -27,6 +27,15 @@ public class RawImporterRepository {
     private static final Set<String> ARCHIVE_EXTENSIONS = Set.of(
             "zip", "7z", "rar", "tar", "gz"
     );
+    private static final Set<String> CONVERSION_STATUSES = Set.of(
+            "success",
+            "failed",
+            "timeout",
+            "unavailable",
+            "disabled",
+            "download_failed",
+            "not_applicable"
+    );
 
     private final JdbcClient jdbcClient;
 
@@ -195,11 +204,15 @@ public class RawImporterRepository {
                 INSERT INTO notice_attachments (
                     notice_id, file_key, original_name, ext, file_type, mime_type,
                     file_size, checksum, source_url, local_path, download_ok,
-                    extracted_text, extracted_chars, parser, parse_quality, parse_ok, download_cached
+                    extracted_text, extracted_chars, parser, parse_quality, parse_ok, download_cached,
+                    preview_pdf_path, preview_pdf_size, preview_pdf_checksum,
+                    conversion_status, conversion_engine, conversion_error
                 ) VALUES (
                     :noticeId, :fileKey, :originalName, :ext, :fileType, :mimeType,
                     :fileSize, :checksum, :sourceUrl, :localPath, :downloadOk,
-                    :extractedText, :extractedChars, :parser, :parseQuality, :parseOk, :downloadCached
+                    :extractedText, :extractedChars, :parser, :parseQuality, :parseOk, :downloadCached,
+                    :previewPdfPath, :previewPdfSize, :previewPdfChecksum,
+                    :conversionStatus, :conversionEngine, :conversionError
                 )
                 ON CONFLICT (file_key) DO UPDATE SET
                     notice_id = EXCLUDED.notice_id,
@@ -217,7 +230,13 @@ public class RawImporterRepository {
                     parser = EXCLUDED.parser,
                     parse_quality = EXCLUDED.parse_quality,
                     parse_ok = EXCLUDED.parse_ok,
-                    download_cached = EXCLUDED.download_cached
+                    download_cached = EXCLUDED.download_cached,
+                    preview_pdf_path = EXCLUDED.preview_pdf_path,
+                    preview_pdf_size = EXCLUDED.preview_pdf_size,
+                    preview_pdf_checksum = EXCLUDED.preview_pdf_checksum,
+                    conversion_status = EXCLUDED.conversion_status,
+                    conversion_engine = EXCLUDED.conversion_engine,
+                    conversion_error = EXCLUDED.conversion_error
                 """;
 
         String fileKey = requireMaxLength(requiredValue(attachment.fileKey(), "file_key"), "file_key", 500);
@@ -227,6 +246,21 @@ public class RawImporterRepository {
         String checksum = requireMaxLength(trimToNull(attachment.checksum()), "checksum", 64);
         String localPath = requireMaxLength(trimToNull(attachment.localPath()), "local_path", 500);
         String parser = requireMaxLength(trimToNull(attachment.parser()), "parser", 50);
+        String previewPdfPath = requireMaxLength(
+                trimToNull(attachment.previewPdfPath()),
+                "preview_pdf_path",
+                500
+        );
+        String previewPdfChecksum = requireMaxLength(
+                trimToNull(attachment.previewPdfChecksum()),
+                "preview_pdf_checksum",
+                64
+        );
+        String conversionEngine = requireMaxLength(
+                trimToNull(attachment.conversionEngine()),
+                "conversion_engine",
+                50
+        );
 
         jdbcClient.sql(sql)
                 .param("noticeId", noticeId)
@@ -246,6 +280,12 @@ public class RawImporterRepository {
                 .param("parseQuality", normalizeParseQuality(attachment.parseQuality()))
                 .param("parseOk", boolOrFalse(attachment.parseOk()))
                 .param("downloadCached", boolOrFalse(attachment.downloadCached()))
+                .param("previewPdfPath", previewPdfPath)
+                .param("previewPdfSize", attachment.previewPdfSize())
+                .param("previewPdfChecksum", previewPdfChecksum)
+                .param("conversionStatus", normalizeConversionStatus(attachment.conversionStatus()))
+                .param("conversionEngine", conversionEngine)
+                .param("conversionError", attachment.conversionError())
                 .update();
     }
 
@@ -305,6 +345,17 @@ public class RawImporterRepository {
             return normalized;
         }
         return "none";
+    }
+
+    private String normalizeConversionStatus(String conversionStatus) {
+        if (conversionStatus == null || conversionStatus.isBlank()) {
+            return "not_applicable";
+        }
+        String normalized = conversionStatus.trim().toLowerCase(Locale.ROOT);
+        if (CONVERSION_STATUSES.contains(normalized)) {
+            return normalized;
+        }
+        return "not_applicable";
     }
 
     private String originalName(RawAttachmentPayload attachment) {

--- a/src/main/java/com/campost/backend/domain/post/notice/dto/NoticeDetailDto.java
+++ b/src/main/java/com/campost/backend/domain/post/notice/dto/NoticeDetailDto.java
@@ -100,6 +100,12 @@ public record NoticeDetailDto(
             "parseQuality",
             "parseOk",
             "downloadCached",
+            "previewPdfPath",
+            "previewPdfSize",
+            "previewPdfChecksum",
+            "conversionStatus",
+            "conversionEngine",
+            "conversionError",
             "createdAt"
     })
     public record AttachmentDto(
@@ -137,6 +143,18 @@ public record NoticeDetailDto(
             Boolean parseOk,
             @JsonProperty("downloadCached")
             Boolean downloadCached,
+            @JsonProperty("previewPdfPath")
+            String previewPdfPath,
+            @JsonProperty("previewPdfSize")
+            Long previewPdfSize,
+            @JsonProperty("previewPdfChecksum")
+            String previewPdfChecksum,
+            @JsonProperty("conversionStatus")
+            String conversionStatus,
+            @JsonProperty("conversionEngine")
+            String conversionEngine,
+            @JsonProperty("conversionError")
+            String conversionError,
             @JsonProperty("createdAt")
             OffsetDateTime createdAt
     ) {

--- a/src/main/java/com/campost/backend/domain/post/notice/repository/NoticeQueryRepository.java
+++ b/src/main/java/com/campost/backend/domain/post/notice/repository/NoticeQueryRepository.java
@@ -123,7 +123,9 @@ public class NoticeQueryRepository {
         String sql = """
                 SELECT id, file_key, original_name, ext, file_type, mime_type, file_size,
                        checksum, source_url, local_path, download_ok, extracted_text,
-                       extracted_chars, parser, parse_quality, parse_ok, download_cached, created_at
+                       extracted_chars, parser, parse_quality, parse_ok, download_cached,
+                       preview_pdf_path, preview_pdf_size, preview_pdf_checksum,
+                       conversion_status, conversion_engine, conversion_error, created_at
                 FROM notice_attachments
                 WHERE notice_id = :noticeId
                 ORDER BY id ASC
@@ -149,6 +151,12 @@ public class NoticeQueryRepository {
                         rs.getString("parse_quality"),
                         rs.getObject("parse_ok", Boolean.class),
                         rs.getObject("download_cached", Boolean.class),
+                        rs.getString("preview_pdf_path"),
+                        rs.getObject("preview_pdf_size", Long.class),
+                        rs.getString("preview_pdf_checksum"),
+                        rs.getString("conversion_status"),
+                        rs.getString("conversion_engine"),
+                        rs.getString("conversion_error"),
                         rs.getObject("created_at", java.time.OffsetDateTime.class)
                 ))
                 .list();

--- a/src/main/resources/db/migration/V13__add_attachment_pdf_preview_fields.sql
+++ b/src/main/resources/db/migration/V13__add_attachment_pdf_preview_fields.sql
@@ -1,0 +1,31 @@
+-- ============================================================
+-- CamPost Notice Attachments - PDF preview metadata
+-- ============================================================
+
+ALTER TABLE notice_attachments
+    ADD COLUMN IF NOT EXISTS preview_pdf_path VARCHAR(500),
+    ADD COLUMN IF NOT EXISTS preview_pdf_size BIGINT,
+    ADD COLUMN IF NOT EXISTS preview_pdf_checksum CHAR(64),
+    ADD COLUMN IF NOT EXISTS conversion_status VARCHAR(20) DEFAULT 'not_applicable',
+    ADD COLUMN IF NOT EXISTS conversion_engine VARCHAR(50),
+    ADD COLUMN IF NOT EXISTS conversion_error TEXT;
+
+ALTER TABLE notice_attachments
+    DROP CONSTRAINT IF EXISTS notice_attachments_conversion_status_check;
+
+ALTER TABLE notice_attachments
+    ADD CONSTRAINT notice_attachments_conversion_status_check
+    CHECK (
+        conversion_status IN (
+            'success',
+            'failed',
+            'timeout',
+            'unavailable',
+            'disabled',
+            'download_failed',
+            'not_applicable'
+        )
+    );
+
+CREATE INDEX IF NOT EXISTS idx_attachments_conversion_status
+ON notice_attachments(conversion_status);


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #59

## 🏷️ PR 타입

- [ ] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)
- [ ] ⚙️ 프로젝트 초기 설정 (Chore)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🚨 PR 복구 (Revert)

## 📝 작업 내용

- 작업한 주요 내용을 bullet point로 정리해주세요.


구현 내용:

  - notice_attachments에 PDF 미리보기 컬럼 추가 migration 생성
  - raw JSON의 preview_pdf_*, conversion_* 필드를 importer가 읽도록 확장
  - DB 저장/업데이트 SQL에 PDF 미리보기 메타데이터 반영
  - 공지 상세 API 첨부파일 DTO에 아래 필드 추가
      - previewPdfPath
      - previewPdfSize
      - previewPdfChecksum
      - conversionStatus
      - conversionEngine
      - conversionError

  수정 파일:

  - Desktop/CAMPOST/CamPost-backend/src/main/resources/db/migration/V13__add_attachment_pdf_preview_fields.sql
  - Desktop/CAMPOST/CamPost-backend/src/main/java/com/campost/backend/domain/collect/importer/model/RawNoticePayload.java
  - Desktop/CAMPOST/CamPost-backend/src/main/java/com/campost/backend/domain/collect/importer/repository/RawImporterRepository.java
  - Desktop/CAMPOST/CamPost-backend/src/main/java/com/campost/backend/domain/post/notice/dto/NoticeDetailDto.java
  - Desktop/CAMPOST/CamPost-backend/src/main/java/com/campost/backend/domain/post/notice/repository/NoticeQueryRepository.java

  검증:

  - mvn -q compile 통과
  - mvn -q test 통과
  - docker compose up -d --build backend 성공

## 📸 스크린샷

- 테스트 결과를 스크린샷으로 첨부해주세요.

## ✅ 체크리스트

- [ ] 코드 리뷰를 받을 준비가 완료되었습니다.
- [ ] 코드 스타일 가이드를 준수했습니다.
- [ ] 셀프 리뷰를 완료했습니다.
- [ ] 테스트를 작성하고 모두 통과했습니다.
- [ ] 문서를 업데이트했습니다. (필요한 경우)

## 📎 기타 참고사항

- 논의가 필요한 부분, 리뷰 시 유의사항 등을 작성해주세요.
