### PR TITLE
Feat(#61): 회원탈퇴 API 구현 

### DIFF
--- a/src/main/java/com/campost/backend/domain/auth/repository/JdbcUserRepository.java
+++ b/src/main/java/com/campost/backend/domain/auth/repository/JdbcUserRepository.java
@@ -172,6 +172,18 @@ public class JdbcUserRepository implements UserRepository {
     }
 
     @Override
+    public boolean deleteById(long userId) {
+        String sql = """
+                DELETE FROM users
+                WHERE id = :userId
+                """;
+
+        return jdbcClient.sql(sql)
+                .param("userId", userId)
+                .update() == 1;
+    }
+
+    @Override
     public Optional<UserOnboardingProfile> updateOnboardingProfile(UserOnboardingProfileUpdateCommand command) {
         String sql = """
                 UPDATE users

--- a/src/main/java/com/campost/backend/domain/auth/repository/UserRepository.java
+++ b/src/main/java/com/campost/backend/domain/auth/repository/UserRepository.java
@@ -27,5 +27,7 @@ public interface UserRepository {
 
     boolean updatePasswordHash(long userId, String passwordHash);
 
+    boolean deleteById(long userId);
+
     Optional<UserOnboardingProfile> updateOnboardingProfile(UserOnboardingProfileUpdateCommand command);
 }

--- a/src/main/java/com/campost/backend/domain/user/controller/UserProfileController.java
+++ b/src/main/java/com/campost/backend/domain/user/controller/UserProfileController.java
@@ -2,9 +2,11 @@ package com.campost.backend.domain.user.controller;
 
 import com.campost.backend.domain.user.dto.OnboardingProfileRequest;
 import com.campost.backend.domain.user.dto.OnboardingProfileResponse;
+import com.campost.backend.domain.user.dto.UserAccountDeleteRequest;
 import com.campost.backend.domain.user.dto.UserPasswordChangeRequest;
 import com.campost.backend.domain.user.dto.UserProfileResponse;
 import com.campost.backend.domain.user.dto.UserProfileUpdateRequest;
+import com.campost.backend.domain.user.service.UserAccountDeleteService;
 import com.campost.backend.domain.user.service.UserOnboardingProfileService;
 import com.campost.backend.domain.user.service.UserPasswordChangeService;
 import com.campost.backend.domain.user.service.UserProfileQueryService;
@@ -21,6 +23,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -35,6 +38,7 @@ public class UserProfileController {
 
     private static final String BEARER_PREFIX = "Bearer ";
 
+    private final UserAccountDeleteService userAccountDeleteService;
     private final UserOnboardingProfileService userOnboardingProfileService;
     private final UserPasswordChangeService userPasswordChangeService;
     private final UserProfileQueryService userProfileQueryService;
@@ -42,17 +46,56 @@ public class UserProfileController {
     private final JwtTokenService jwtTokenService;
 
     public UserProfileController(
+            UserAccountDeleteService userAccountDeleteService,
             UserOnboardingProfileService userOnboardingProfileService,
             UserPasswordChangeService userPasswordChangeService,
             UserProfileQueryService userProfileQueryService,
             UserProfileUpdateService userProfileUpdateService,
             JwtTokenService jwtTokenService
     ) {
+        this.userAccountDeleteService = userAccountDeleteService;
         this.userOnboardingProfileService = userOnboardingProfileService;
         this.userPasswordChangeService = userPasswordChangeService;
         this.userProfileQueryService = userProfileQueryService;
         this.userProfileUpdateService = userProfileUpdateService;
         this.jwtTokenService = jwtTokenService;
+    }
+
+    @Operation(
+            summary = "Account deletion",
+            description = "Deletes the authenticated user's account after verifying the current password.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "Account deletion succeeded"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "Request validation failed",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "Authentication failed or current password mismatch",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "User not found",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+    @DeleteMapping("/me")
+    public ApiResponse<Void> deleteMyAccount(
+            @RequestHeader(name = "Authorization", required = false) String authorization,
+            @Valid @RequestBody UserAccountDeleteRequest request
+    ) {
+        long userId = resolveUserId(authorization);
+        userAccountDeleteService.deleteAccount(userId, request);
+
+        return ApiResponse.ok(null);
     }
 
     @Operation(

--- a/src/main/java/com/campost/backend/domain/user/controller/UserProfileController.java
+++ b/src/main/java/com/campost/backend/domain/user/controller/UserProfileController.java
@@ -62,28 +62,28 @@ public class UserProfileController {
     }
 
     @Operation(
-            summary = "Account deletion",
-            description = "Deletes the authenticated user's account after verifying the current password.",
+            summary = "회원탈퇴",
+            description = "로그인한 사용자의 현재 비밀번호를 확인한 뒤 계정을 삭제합니다.",
             security = @SecurityRequirement(name = "bearerAuth")
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
                     responseCode = "200",
-                    description = "Account deletion succeeded"
+                    description = "회원탈퇴 성공"
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
                     responseCode = "400",
-                    description = "Request validation failed",
+                    description = "입력값 검증 실패",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
                     responseCode = "401",
-                    description = "Authentication failed or current password mismatch",
+                    description = "인증 실패 또는 현재 비밀번호 불일치",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
                     responseCode = "404",
-                    description = "User not found",
+                    description = "사용자를 찾을 수 없음",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))
             )
     })

--- a/src/main/java/com/campost/backend/domain/user/dto/UserAccountDeleteRequest.java
+++ b/src/main/java/com/campost/backend/domain/user/dto/UserAccountDeleteRequest.java
@@ -1,0 +1,9 @@
+package com.campost.backend.domain.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UserAccountDeleteRequest(
+        @NotBlank(message = "현재 비밀번호를 입력해주세요.")
+        String currentPassword
+) {
+}

--- a/src/main/java/com/campost/backend/domain/user/service/UserAccountDeleteService.java
+++ b/src/main/java/com/campost/backend/domain/user/service/UserAccountDeleteService.java
@@ -1,0 +1,41 @@
+package com.campost.backend.domain.user.service;
+
+import com.campost.backend.domain.auth.exception.BadCredentialsException;
+import com.campost.backend.domain.auth.model.User;
+import com.campost.backend.domain.auth.repository.UserRepository;
+import com.campost.backend.domain.auth.service.PasswordHashService;
+import com.campost.backend.domain.user.dto.UserAccountDeleteRequest;
+import com.campost.backend.domain.user.exception.UserNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class UserAccountDeleteService {
+
+    private final UserRepository userRepository;
+    private final PasswordHashService passwordHashService;
+
+    public UserAccountDeleteService(
+            UserRepository userRepository,
+            PasswordHashService passwordHashService
+    ) {
+        this.userRepository = userRepository;
+        this.passwordHashService = passwordHashService;
+    }
+
+    @Transactional
+    public void deleteAccount(long userId, UserAccountDeleteRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
+
+        if (!passwordHashService.matches(request.currentPassword(), user.passwordHash())) {
+            throw new BadCredentialsException();
+        }
+
+        boolean deleted = userRepository.deleteById(userId);
+
+        if (!deleted) {
+            throw new UserNotFoundException();
+        }
+    }
+}

--- a/src/test/java/com/campost/backend/domain/auth/service/EmailVerificationServiceTest.java
+++ b/src/test/java/com/campost/backend/domain/auth/service/EmailVerificationServiceTest.java
@@ -207,6 +207,11 @@ class EmailVerificationServiceTest {
         }
 
         @Override
+        public boolean deleteById(long userId) {
+            throw new UnsupportedOperationException("Not used in this test.");
+        }
+
+        @Override
         public Optional<UserOnboardingProfile> updateOnboardingProfile(UserOnboardingProfileUpdateCommand command) {
             throw new UnsupportedOperationException("Not used in this test.");
         }

--- a/src/test/java/com/campost/backend/domain/auth/service/LoginServiceTest.java
+++ b/src/test/java/com/campost/backend/domain/auth/service/LoginServiceTest.java
@@ -107,6 +107,11 @@ class LoginServiceTest {
         }
 
         @Override
+        public boolean deleteById(long userId) {
+            throw new UnsupportedOperationException("Not used in this test.");
+        }
+
+        @Override
         public Optional<UserOnboardingProfile> updateOnboardingProfile(UserOnboardingProfileUpdateCommand command) {
             throw new UnsupportedOperationException("Not used in this test.");
         }

--- a/src/test/java/com/campost/backend/domain/auth/service/SignupUserServiceTest.java
+++ b/src/test/java/com/campost/backend/domain/auth/service/SignupUserServiceTest.java
@@ -243,6 +243,11 @@ class SignupUserServiceTest {
         }
 
         @Override
+        public boolean deleteById(long userId) {
+            throw new UnsupportedOperationException("Not used in this test.");
+        }
+
+        @Override
         public Optional<UserOnboardingProfile> updateOnboardingProfile(UserOnboardingProfileUpdateCommand command) {
             throw new UnsupportedOperationException("Not used in this test.");
         }

--- a/src/test/java/com/campost/backend/domain/user/dto/UserAccountDeleteRequestValidationTest.java
+++ b/src/test/java/com/campost/backend/domain/user/dto/UserAccountDeleteRequestValidationTest.java
@@ -1,0 +1,26 @@
+package com.campost.backend.domain.user.dto;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UserAccountDeleteRequestValidationTest {
+
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+    @Test
+    void currentPasswordIsRequired() {
+        UserAccountDeleteRequest request = new UserAccountDeleteRequest("");
+
+        assertThat(validator.validate(request)).isNotEmpty();
+    }
+
+    @Test
+    void validRequestPassesValidation() {
+        UserAccountDeleteRequest request = new UserAccountDeleteRequest("password123");
+
+        assertThat(validator.validate(request)).isEmpty();
+    }
+}

--- a/src/test/java/com/campost/backend/domain/user/service/UserAccountDeleteServiceTest.java
+++ b/src/test/java/com/campost/backend/domain/user/service/UserAccountDeleteServiceTest.java
@@ -5,8 +5,7 @@ import com.campost.backend.domain.auth.model.SignupUserCreateCommand;
 import com.campost.backend.domain.auth.model.User;
 import com.campost.backend.domain.auth.repository.UserRepository;
 import com.campost.backend.domain.auth.service.PasswordHashService;
-import com.campost.backend.domain.user.dto.UserPasswordChangeRequest;
-import com.campost.backend.domain.user.exception.SamePasswordException;
+import com.campost.backend.domain.user.dto.UserAccountDeleteRequest;
 import com.campost.backend.domain.user.exception.UserNotFoundException;
 import com.campost.backend.domain.user.model.UserOnboardingProfile;
 import com.campost.backend.domain.user.model.UserOnboardingProfileUpdateCommand;
@@ -20,70 +19,55 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-class UserPasswordChangeServiceTest {
+class UserAccountDeleteServiceTest {
 
     private final FakeUserRepository userRepository = new FakeUserRepository();
     private final PasswordHashService passwordHashService = new PasswordHashService();
-    private final UserPasswordChangeService service = new UserPasswordChangeService(
+    private final UserAccountDeleteService service = new UserAccountDeleteService(
             userRepository,
             passwordHashService
     );
 
     @Test
-    void changePasswordVerifiesCurrentPasswordAndStoresHashedNewPassword() {
+    void deleteAccountVerifiesCurrentPasswordAndDeletesUser() {
         userRepository.user = Optional.of(userWithPasswordHash(passwordHashService.hash("password123")));
 
-        service.changePassword(1L, new UserPasswordChangeRequest("password123", "newPassword123"));
+        service.deleteAccount(1L, new UserAccountDeleteRequest("password123"));
 
         assertThat(userRepository.checkedUserId).isEqualTo(1L);
-        assertThat(userRepository.updatedUserId).isEqualTo(1L);
-        assertThat(userRepository.updatedPasswordHash).isNotEqualTo("newPassword123");
-        assertThat(userRepository.updatedPasswordHash).doesNotContain("newPassword123");
-        assertThat(passwordHashService.matches("newPassword123", userRepository.updatedPasswordHash)).isTrue();
+        assertThat(userRepository.deletedUserId).isEqualTo(1L);
     }
 
     @Test
-    void changePasswordThrowsExceptionWhenCurrentPasswordDoesNotMatch() {
+    void deleteAccountThrowsExceptionWhenCurrentPasswordDoesNotMatch() {
         userRepository.user = Optional.of(userWithPasswordHash(passwordHashService.hash("password123")));
 
-        assertThatThrownBy(() -> service.changePassword(
+        assertThatThrownBy(() -> service.deleteAccount(
                 1L,
-                new UserPasswordChangeRequest("wrongPassword123", "newPassword123")
+                new UserAccountDeleteRequest("wrongPassword123")
         )).isInstanceOf(BadCredentialsException.class);
 
-        assertThat(userRepository.updatedPasswordHash).isNull();
+        assertThat(userRepository.deletedUserId).isZero();
     }
 
     @Test
-    void changePasswordRejectsSamePasswordWithoutUpdating() {
-        userRepository.user = Optional.of(userWithPasswordHash(passwordHashService.hash("password123")));
-
-        assertThatThrownBy(() -> service.changePassword(
-                1L,
-                new UserPasswordChangeRequest("password123", "password123")
-        )).isInstanceOf(SamePasswordException.class);
-
-        assertThat(userRepository.updatedPasswordHash).isNull();
-    }
-
-    @Test
-    void changePasswordThrowsExceptionWhenUserDoesNotExist() {
+    void deleteAccountThrowsExceptionWhenUserDoesNotExist() {
         userRepository.user = Optional.empty();
 
-        assertThatThrownBy(() -> service.changePassword(
+        assertThatThrownBy(() -> service.deleteAccount(
                 999L,
-                new UserPasswordChangeRequest("password123", "newPassword123")
+                new UserAccountDeleteRequest("password123")
         )).isInstanceOf(UserNotFoundException.class);
     }
 
     @Test
-    void changePasswordThrowsExceptionWhenUpdateFails() {
+    void deleteAccountThrowsExceptionWhenDeleteFails() {
         userRepository.user = Optional.of(userWithPasswordHash(passwordHashService.hash("password123")));
-        userRepository.updateResult = false;
+        userRepository.deleteResult = false;
 
-        assertThatThrownBy(() -> service.changePassword(
+        assertThatThrownBy(() -> service.deleteAccount(
                 1L,
-                new UserPasswordChangeRequest("password123", "newPassword123")
+                new UserAccountDeleteRequest("password123")
         )).isInstanceOf(UserNotFoundException.class);
     }
 
@@ -103,9 +87,8 @@ class UserPasswordChangeServiceTest {
 
         private Optional<User> user = Optional.empty();
         private long checkedUserId;
-        private long updatedUserId;
-        private String updatedPasswordHash;
-        private boolean updateResult = true;
+        private long deletedUserId;
+        private boolean deleteResult = true;
 
         @Override
         public User save(SignupUserCreateCommand command) {
@@ -145,14 +128,13 @@ class UserPasswordChangeServiceTest {
 
         @Override
         public boolean updatePasswordHash(long userId, String passwordHash) {
-            this.updatedUserId = userId;
-            this.updatedPasswordHash = passwordHash;
-            return updateResult;
+            throw new UnsupportedOperationException("Not used in this test.");
         }
 
         @Override
         public boolean deleteById(long userId) {
-            throw new UnsupportedOperationException("Not used in this test.");
+            this.deletedUserId = userId;
+            return deleteResult;
         }
 
         @Override

--- a/src/test/java/com/campost/backend/domain/user/service/UserOnboardingProfileServiceTest.java
+++ b/src/test/java/com/campost/backend/domain/user/service/UserOnboardingProfileServiceTest.java
@@ -94,6 +94,11 @@ class UserOnboardingProfileServiceTest {
         }
 
         @Override
+        public boolean deleteById(long userId) {
+            throw new UnsupportedOperationException("Not used in this test.");
+        }
+
+        @Override
         public Optional<UserOnboardingProfile> updateOnboardingProfile(UserOnboardingProfileUpdateCommand command) {
             this.savedCommand = command;
             if (updatedProfile != null) {

--- a/src/test/java/com/campost/backend/domain/user/service/UserProfileQueryServiceTest.java
+++ b/src/test/java/com/campost/backend/domain/user/service/UserProfileQueryServiceTest.java
@@ -106,6 +106,11 @@ class UserProfileQueryServiceTest {
         }
 
         @Override
+        public boolean deleteById(long userId) {
+            throw new UnsupportedOperationException("Not used in this test.");
+        }
+
+        @Override
         public Optional<UserOnboardingProfile> updateOnboardingProfile(UserOnboardingProfileUpdateCommand command) {
             throw new UnsupportedOperationException("Not used in this test.");
         }

--- a/src/test/java/com/campost/backend/domain/user/service/UserProfileUpdateServiceTest.java
+++ b/src/test/java/com/campost/backend/domain/user/service/UserProfileUpdateServiceTest.java
@@ -109,6 +109,11 @@ class UserProfileUpdateServiceTest {
         }
 
         @Override
+        public boolean deleteById(long userId) {
+            throw new UnsupportedOperationException("Not used in this test.");
+        }
+
+        @Override
         public Optional<UserOnboardingProfile> updateOnboardingProfile(UserOnboardingProfileUpdateCommand command) {
             throw new UnsupportedOperationException("Not used in this test.");
         }


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #61 

## 🏷️ PR 타입

- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)
- [ ] ⚙️ 프로젝트 초기 설정 (Chore)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🚨 PR 복구 (Revert)

## 📝 작업 내용

- 로그인한 사용자의 계정을 삭제하는 API 추가
  - `DELETE /api/v1/users/me`
  - Authorization Bearer 토큰으로 사용자 식별
  - 현재 비밀번호 검증 후 계정 삭제

- 회원탈퇴 요청 DTO 추가
  - `currentPassword` 필수값 검증

- 사용자 삭제 서비스 로직 추가
  - 사용자 존재 여부 확인
  - 현재 비밀번호 불일치 시 `AUTH401_CREDENTIALS` 응답 흐름 사용
  - 삭제 실패 시 `UserNotFoundException` 처리

- Repository 삭제 메서드 추가
  - `UserRepository.deleteById`
  - `JdbcUserRepository`에서 `DELETE FROM users WHERE id = :userId`
  - 기존 DB 스키마상 bookmarks / keywords / notifications는 `ON DELETE CASCADE`로 함께 정리됨

- 테스트 추가 및 기존 Fake Repository 보강
  - 회원탈퇴 요청 DTO validation 테스트
  - 회원탈퇴 서비스 단위 테스트
  - 성공 / 비밀번호 불일치 / 사용자 없음 / 삭제 실패 케이스 검증

## 📸 스크린샷

- 테스트 결과를 스크린샷으로 첨부해주세요.

## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다.
- [x] 코드 스타일 가이드를 준수했습니다.
- [x] 셀프 리뷰를 완료했습니다.
- [x] 테스트를 작성하고 모두 통과했습니다.
- [ ] 문서를 업데이트했습니다. (필요한 경우)

## 📎 기타 참고사항

- 논의가 필요한 부분, 리뷰 시 유의사항 등을 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 사용자가 자신의 계정을 삭제할 수 있는 기능이 추가되었습니다.
  * 계정 삭제 시 현재 비밀번호 확인을 통한 추가 보안 계층이 적용됩니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Team-CamPost/CamPost-backend/pull/62?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->