### PR TITLE
Feat(#63): JWT 로그인 토큰 발급 구현

### DIFF
--- a/src/main/java/com/campost/backend/domain/auth/dto/LoginResponse.java
+++ b/src/main/java/com/campost/backend/domain/auth/dto/LoginResponse.java
@@ -1,11 +1,36 @@
 package com.campost.backend.domain.auth.dto;
 
 public record LoginResponse(
+        long userId,
+        String username,
+        String name,
+        String role,
         String accessToken,
+        String refreshToken,
         String tokenType,
-        String name
+        long expiresIn,
+        long refreshTokenExpiresIn
 ) {
-    public static LoginResponse of(String accessToken, String name) {
-        return new LoginResponse(accessToken, "Bearer", name);
+    public static LoginResponse of(
+            long userId,
+            String username,
+            String name,
+            String role,
+            String accessToken,
+            String refreshToken,
+            long expiresIn,
+            long refreshTokenExpiresIn
+    ) {
+        return new LoginResponse(
+                userId,
+                username,
+                name,
+                role,
+                accessToken,
+                refreshToken,
+                "Bearer",
+                expiresIn,
+                refreshTokenExpiresIn
+        );
     }
 }

--- a/src/main/java/com/campost/backend/domain/auth/service/LoginService.java
+++ b/src/main/java/com/campost/backend/domain/auth/service/LoginService.java
@@ -46,12 +46,7 @@ public class LoginService {
                 user.name(),
                 user.role()
         );
-        String refreshToken = jwtTokenService.generateRefreshToken(
-                user.id(),
-                user.username(),
-                user.name(),
-                user.role()
-        );
+        String refreshToken = jwtTokenService.generateRefreshToken(user.id());
 
         return LoginResponse.of(
                 user.id(),

--- a/src/main/java/com/campost/backend/domain/auth/service/LoginService.java
+++ b/src/main/java/com/campost/backend/domain/auth/service/LoginService.java
@@ -40,7 +40,28 @@ public class LoginService {
         }
 
         User user = foundUser.get();
-        String token = jwtTokenService.generate(user.id(), user.username(), user.name(), user.role());
-        return LoginResponse.of(token, user.name());
+        String accessToken = jwtTokenService.generateAccessToken(
+                user.id(),
+                user.username(),
+                user.name(),
+                user.role()
+        );
+        String refreshToken = jwtTokenService.generateRefreshToken(
+                user.id(),
+                user.username(),
+                user.name(),
+                user.role()
+        );
+
+        return LoginResponse.of(
+                user.id(),
+                user.username(),
+                user.name(),
+                user.role(),
+                accessToken,
+                refreshToken,
+                jwtTokenService.accessTokenExpiryMs() / 1000,
+                jwtTokenService.refreshTokenExpiryMs() / 1000
+        );
     }
 }

--- a/src/main/java/com/campost/backend/global/jwt/JwtTokenService.java
+++ b/src/main/java/com/campost/backend/global/jwt/JwtTokenService.java
@@ -5,6 +5,7 @@ import com.campost.backend.global.exception.TokenExpiredException;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.JwtBuilder;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import org.springframework.beans.factory.annotation.Value;
@@ -38,8 +39,8 @@ public class JwtTokenService {
         return generate(userId, username, name, role, ACCESS_TOKEN_TYPE, accessTokenExpiryMs);
     }
 
-    public String generateRefreshToken(long userId, String username, String name, String role) {
-        return generate(userId, username, name, role, REFRESH_TOKEN_TYPE, refreshTokenExpiryMs);
+    public String generateRefreshToken(long userId) {
+        return generate(userId, null, null, null, REFRESH_TOKEN_TYPE, refreshTokenExpiryMs);
     }
 
     public long accessTokenExpiryMs() {
@@ -59,16 +60,26 @@ public class JwtTokenService {
             long expiryMs
     ) {
         Date now = new Date();
-        return Jwts.builder()
+        JwtBuilder builder = Jwts.builder()
                 .subject(String.valueOf(userId))
-                .claim("username", username)
-                .claim("name", name)
-                .claim("role", role)
                 .claim("tokenType", tokenType)
                 .issuedAt(now)
                 .expiration(new Date(now.getTime() + expiryMs))
-                .signWith(secretKey)
-                .compact();
+                .signWith(secretKey);
+
+        if (username != null) {
+            builder.claim("username", username);
+        }
+
+        if (name != null) {
+            builder.claim("name", name);
+        }
+
+        if (role != null) {
+            builder.claim("role", role);
+        }
+
+        return builder.compact();
     }
 
     public Claims parse(String token) {

--- a/src/main/java/com/campost/backend/global/jwt/JwtTokenService.java
+++ b/src/main/java/com/campost/backend/global/jwt/JwtTokenService.java
@@ -17,24 +17,54 @@ import java.util.Date;
 @Component
 public class JwtTokenService {
 
+    public static final String ACCESS_TOKEN_TYPE = "access";
+    public static final String REFRESH_TOKEN_TYPE = "refresh";
+
     private final SecretKey secretKey;
-    private final long expiryMs;
+    private final long accessTokenExpiryMs;
+    private final long refreshTokenExpiryMs;
 
     public JwtTokenService(
             @Value("${app.jwt.secret}") String secret,
-            @Value("${app.jwt.expiry-ms}") long expiryMs
+            @Value("${app.jwt.access-expiry-ms}") long accessTokenExpiryMs,
+            @Value("${app.jwt.refresh-expiry-ms}") long refreshTokenExpiryMs
     ) {
         this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
-        this.expiryMs = expiryMs;
+        this.accessTokenExpiryMs = accessTokenExpiryMs;
+        this.refreshTokenExpiryMs = refreshTokenExpiryMs;
     }
 
-    public String generate(long userId, String username, String name, String role) {
+    public String generateAccessToken(long userId, String username, String name, String role) {
+        return generate(userId, username, name, role, ACCESS_TOKEN_TYPE, accessTokenExpiryMs);
+    }
+
+    public String generateRefreshToken(long userId, String username, String name, String role) {
+        return generate(userId, username, name, role, REFRESH_TOKEN_TYPE, refreshTokenExpiryMs);
+    }
+
+    public long accessTokenExpiryMs() {
+        return accessTokenExpiryMs;
+    }
+
+    public long refreshTokenExpiryMs() {
+        return refreshTokenExpiryMs;
+    }
+
+    private String generate(
+            long userId,
+            String username,
+            String name,
+            String role,
+            String tokenType,
+            long expiryMs
+    ) {
         Date now = new Date();
         return Jwts.builder()
                 .subject(String.valueOf(userId))
                 .claim("username", username)
                 .claim("name", name)
                 .claim("role", role)
+                .claim("tokenType", tokenType)
                 .issuedAt(now)
                 .expiration(new Date(now.getTime() + expiryMs))
                 .signWith(secretKey)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,7 +30,8 @@ app:
     allowed-origins: ${APP_CORS_ALLOWED_ORIGINS}
   jwt:
     secret: ${JWT_SECRET}
-    expiry-ms: ${JWT_EXPIRY_MS}
+    access-expiry-ms: ${JWT_EXPIRY_MS}
+    refresh-expiry-ms: ${JWT_REFRESH_EXPIRY_MS:1209600000}
   mail:
     verification-sender: ${APP_MAIL_VERIFICATION_SENDER:logging}
     from: ${APP_MAIL_FROM:no-reply@campost.local}

--- a/src/test/java/com/campost/backend/domain/auth/service/LoginServiceTest.java
+++ b/src/test/java/com/campost/backend/domain/auth/service/LoginServiceTest.java
@@ -67,7 +67,9 @@ class LoginServiceTest {
         assertThat(accessClaims.get("role", String.class)).isEqualTo("USER");
         assertThat(accessClaims.get("tokenType", String.class)).isEqualTo(JwtTokenService.ACCESS_TOKEN_TYPE);
         assertThat(refreshClaims.getSubject()).isEqualTo("1");
-        assertThat(refreshClaims.get("role", String.class)).isEqualTo("USER");
+        assertThat(refreshClaims.get("username")).isNull();
+        assertThat(refreshClaims.get("name")).isNull();
+        assertThat(refreshClaims.get("role")).isNull();
         assertThat(refreshClaims.get("tokenType", String.class)).isEqualTo(JwtTokenService.REFRESH_TOKEN_TYPE);
     }
 

--- a/src/test/java/com/campost/backend/domain/auth/service/LoginServiceTest.java
+++ b/src/test/java/com/campost/backend/domain/auth/service/LoginServiceTest.java
@@ -1,6 +1,7 @@
 package com.campost.backend.domain.auth.service;
 
 import com.campost.backend.domain.auth.dto.LoginRequest;
+import com.campost.backend.domain.auth.dto.LoginResponse;
 import com.campost.backend.domain.auth.exception.BadCredentialsException;
 import com.campost.backend.domain.auth.model.SignupUserCreateCommand;
 import com.campost.backend.domain.auth.model.User;
@@ -10,6 +11,7 @@ import com.campost.backend.domain.user.model.UserOnboardingProfileUpdateCommand;
 import com.campost.backend.domain.user.model.UserProfile;
 import com.campost.backend.domain.user.model.UserProfileUpdateCommand;
 import com.campost.backend.global.jwt.JwtTokenService;
+import io.jsonwebtoken.Claims;
 import org.junit.jupiter.api.Test;
 
 import java.time.OffsetDateTime;
@@ -21,14 +23,53 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 class LoginServiceTest {
 
     private static final String JWT_SECRET = "01234567890123456789012345678901";
+    private static final long ACCESS_TOKEN_EXPIRY_MS = 3_600_000L;
+    private static final long REFRESH_TOKEN_EXPIRY_MS = 1_209_600_000L;
 
     private final FakeUserRepository userRepository = new FakeUserRepository();
     private final CountingPasswordHashService passwordHashService = new CountingPasswordHashService();
+    private final JwtTokenService jwtTokenService = new JwtTokenService(
+            JWT_SECRET,
+            ACCESS_TOKEN_EXPIRY_MS,
+            REFRESH_TOKEN_EXPIRY_MS
+    );
     private final LoginService loginService = new LoginService(
             userRepository,
             passwordHashService,
-            new JwtTokenService(JWT_SECRET, 3_600_000L)
+            jwtTokenService
     );
+
+    @Test
+    void loginReturnsAccessTokenAndRefreshTokenWithUserClaims() {
+        userRepository.foundUser = Optional.of(new User(
+                1L,
+                "campost123",
+                "CamPost User",
+                "campost@example.com",
+                "real-hash",
+                "USER",
+                OffsetDateTime.now()
+        ));
+
+        LoginResponse response = loginService.login(new LoginRequest("campost123", "password123"));
+
+        Claims accessClaims = jwtTokenService.parse(response.accessToken());
+        Claims refreshClaims = jwtTokenService.parse(response.refreshToken());
+
+        assertThat(response.userId()).isEqualTo(1L);
+        assertThat(response.username()).isEqualTo("campost123");
+        assertThat(response.name()).isEqualTo("CamPost User");
+        assertThat(response.role()).isEqualTo("USER");
+        assertThat(response.tokenType()).isEqualTo("Bearer");
+        assertThat(response.expiresIn()).isEqualTo(ACCESS_TOKEN_EXPIRY_MS / 1000);
+        assertThat(response.refreshTokenExpiresIn()).isEqualTo(REFRESH_TOKEN_EXPIRY_MS / 1000);
+        assertThat(accessClaims.getSubject()).isEqualTo("1");
+        assertThat(accessClaims.get("role", String.class)).isEqualTo("USER");
+        assertThat(accessClaims.get("tokenType", String.class)).isEqualTo(JwtTokenService.ACCESS_TOKEN_TYPE);
+        assertThat(refreshClaims.getSubject()).isEqualTo("1");
+        assertThat(refreshClaims.get("role", String.class)).isEqualTo("USER");
+        assertThat(refreshClaims.get("tokenType", String.class)).isEqualTo(JwtTokenService.REFRESH_TOKEN_TYPE);
+    }
 
     @Test
     void loginUsesDummyPasswordHashWhenUserDoesNotExist() {

--- a/src/test/java/com/campost/backend/global/jwt/JwtTokenServiceTest.java
+++ b/src/test/java/com/campost/backend/global/jwt/JwtTokenServiceTest.java
@@ -1,15 +1,49 @@
 package com.campost.backend.global.jwt;
 
 import com.campost.backend.global.exception.InvalidTokenException;
+import io.jsonwebtoken.Claims;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class JwtTokenServiceTest {
 
     private static final String JWT_SECRET = "01234567890123456789012345678901";
+    private static final long ACCESS_TOKEN_EXPIRY_MS = 3_600_000L;
+    private static final long REFRESH_TOKEN_EXPIRY_MS = 1_209_600_000L;
 
-    private final JwtTokenService jwtTokenService = new JwtTokenService(JWT_SECRET, 3_600_000L);
+    private final JwtTokenService jwtTokenService = new JwtTokenService(
+            JWT_SECRET,
+            ACCESS_TOKEN_EXPIRY_MS,
+            REFRESH_TOKEN_EXPIRY_MS
+    );
+
+    @Test
+    void generateAccessTokenIncludesUserClaimsAndAccessTokenType() {
+        String token = jwtTokenService.generateAccessToken(1L, "campost123", "CamPost User", "USER");
+
+        Claims claims = jwtTokenService.parse(token);
+
+        assertThat(claims.getSubject()).isEqualTo("1");
+        assertThat(claims.get("username", String.class)).isEqualTo("campost123");
+        assertThat(claims.get("name", String.class)).isEqualTo("CamPost User");
+        assertThat(claims.get("role", String.class)).isEqualTo("USER");
+        assertThat(claims.get("tokenType", String.class)).isEqualTo(JwtTokenService.ACCESS_TOKEN_TYPE);
+        assertThat(tokenLifetimeMs(claims)).isCloseTo(ACCESS_TOKEN_EXPIRY_MS, withinOneSecond());
+    }
+
+    @Test
+    void generateRefreshTokenIncludesUserClaimsAndRefreshTokenType() {
+        String token = jwtTokenService.generateRefreshToken(1L, "campost123", "CamPost User", "USER");
+
+        Claims claims = jwtTokenService.parse(token);
+
+        assertThat(claims.getSubject()).isEqualTo("1");
+        assertThat(claims.get("role", String.class)).isEqualTo("USER");
+        assertThat(claims.get("tokenType", String.class)).isEqualTo(JwtTokenService.REFRESH_TOKEN_TYPE);
+        assertThat(tokenLifetimeMs(claims)).isCloseTo(REFRESH_TOKEN_EXPIRY_MS, withinOneSecond());
+    }
 
     @Test
     void parseThrowsInvalidTokenExceptionWhenTokenIsNull() {
@@ -21,5 +55,13 @@ class JwtTokenServiceTest {
     void parseThrowsInvalidTokenExceptionWhenTokenIsEmpty() {
         assertThatThrownBy(() -> jwtTokenService.parse(""))
                 .isInstanceOf(InvalidTokenException.class);
+    }
+
+    private long tokenLifetimeMs(Claims claims) {
+        return claims.getExpiration().getTime() - claims.getIssuedAt().getTime();
+    }
+
+    private org.assertj.core.data.Offset<Long> withinOneSecond() {
+        return org.assertj.core.data.Offset.offset(1_000L);
     }
 }

--- a/src/test/java/com/campost/backend/global/jwt/JwtTokenServiceTest.java
+++ b/src/test/java/com/campost/backend/global/jwt/JwtTokenServiceTest.java
@@ -34,13 +34,15 @@ class JwtTokenServiceTest {
     }
 
     @Test
-    void generateRefreshTokenIncludesUserClaimsAndRefreshTokenType() {
-        String token = jwtTokenService.generateRefreshToken(1L, "campost123", "CamPost User", "USER");
+    void generateRefreshTokenIncludesOnlyUserIdAndRefreshTokenType() {
+        String token = jwtTokenService.generateRefreshToken(1L);
 
         Claims claims = jwtTokenService.parse(token);
 
         assertThat(claims.getSubject()).isEqualTo("1");
-        assertThat(claims.get("role", String.class)).isEqualTo("USER");
+        assertThat(claims.get("username")).isNull();
+        assertThat(claims.get("name")).isNull();
+        assertThat(claims.get("role")).isNull();
         assertThat(claims.get("tokenType", String.class)).isEqualTo(JwtTokenService.REFRESH_TOKEN_TYPE);
         assertThat(tokenLifetimeMs(claims)).isCloseTo(REFRESH_TOKEN_EXPIRY_MS, withinOneSecond());
     }


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #63 

## 🏷️ PR 타입

- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)
- [ ] ⚙️ 프로젝트 초기 설정 (Chore)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🚨 PR 복구 (Revert)

## 📝 작업 내용

- 로그인 성공 응답에 Access Token / Refresh Token 동시 발급 추가
  - 기존 `accessToken` 유지
  - `refreshToken` 추가
  - `tokenType: Bearer` 유지
  - `expiresIn`, `refreshTokenExpiresIn` 추가

- JWT 토큰 클레임 확장
  - subject: 사용자 ID
  - `username`
  - `name`
  - `role`
  - `tokenType`: `access` 또는 `refresh`

- Access Token / Refresh Token 만료 시간 분리
  - Access Token: 기존 `JWT_EXPIRY_MS` 사용
  - Refresh Token: `JWT_REFRESH_EXPIRY_MS` 사용
  - `JWT_REFRESH_EXPIRY_MS`가 없으면 기본 14일 사용

- 로그인 응답 DTO 확장
  - `userId`
  - `username`
  - `name`
  - `role`
  - `accessToken`
  - `refreshToken`
  - `tokenType`
  - `expiresIn`
  - `refreshTokenExpiresIn`

- 테스트 보강
  - Access Token 클레임 및 만료 시간 검증
  - Refresh Token 클레임 및 만료 시간 검증
  - 로그인 성공 시 두 토큰 모두 반환되는지 검증

## 📸 스크린샷

- 테스트 결과를 스크린샷으로 첨부해주세요.

## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다.
- [x] 코드 스타일 가이드를 준수했습니다.
- [x] 셀프 리뷰를 완료했습니다.
- [x] 테스트를 작성하고 모두 통과했습니다.
- [ ] 문서를 업데이트했습니다. (필요한 경우)

## 📎 기타 참고사항

- 논의가 필요한 부분, 리뷰 시 유의사항 등을 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새 기능
- 로그인 시 액세스 토큰과 리프레시 토큰이 분리되어 발급됩니다.
- 로그인 응답에 사용자 정보(ID, 사용자명, 이름, 역할) 및 토큰 유형이 포함됩니다.
- 액세스 토큰과 리프레시 토큰의 만료 시간이 개별적으로 관리됩니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Team-CamPost/CamPost-backend/pull/64?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->