### PR TITLE
Feat(#65): JWT Refresh Token 재발급 API 구현

### DIFF
--- a/src/main/java/com/campost/backend/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/campost/backend/domain/auth/controller/AuthController.java
@@ -8,10 +8,13 @@ import com.campost.backend.domain.auth.dto.LoginRequest;
 import com.campost.backend.domain.auth.dto.LoginResponse;
 import com.campost.backend.domain.auth.dto.SignupRequest;
 import com.campost.backend.domain.auth.dto.SignupResponse;
+import com.campost.backend.domain.auth.dto.TokenRefreshRequest;
+import com.campost.backend.domain.auth.dto.TokenRefreshResponse;
 import com.campost.backend.domain.auth.dto.UsernameAvailabilityResponse;
 import com.campost.backend.domain.auth.service.EmailVerificationService;
 import com.campost.backend.domain.auth.service.LoginService;
 import com.campost.backend.domain.auth.service.SignupUserService;
+import com.campost.backend.domain.auth.service.TokenRefreshService;
 import com.campost.backend.domain.auth.validation.AuthValidationRules;
 import com.campost.backend.global.api.ApiCode;
 import com.campost.backend.global.api.ApiResponse;
@@ -42,15 +45,18 @@ public class AuthController {
     private final SignupUserService signupUserService;
     private final EmailVerificationService emailVerificationService;
     private final LoginService loginService;
+    private final TokenRefreshService tokenRefreshService;
 
     public AuthController(
             SignupUserService signupUserService,
             EmailVerificationService emailVerificationService,
-            LoginService loginService
+            LoginService loginService,
+            TokenRefreshService tokenRefreshService
     ) {
         this.signupUserService = signupUserService;
         this.emailVerificationService = emailVerificationService;
         this.loginService = loginService;
+        this.tokenRefreshService = tokenRefreshService;
     }
 
     @Operation(
@@ -71,6 +77,38 @@ public class AuthController {
     @PostMapping("/login")
     public ApiResponse<LoginResponse> login(@Valid @RequestBody LoginRequest request) {
         return ApiResponse.ok(ApiCode.AUTH200_LOGIN, loginService.login(request));
+    }
+
+    @Operation(
+            summary = "Access Token 재발급",
+            description = "Refresh Token을 검증하고 최신 사용자 정보로 새 Access Token을 발급합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "Access Token 재발급 성공"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "입력값 검증 실패",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "만료되었거나 유효하지 않은 Refresh Token",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "사용자를 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+    @PostMapping("/token/refresh")
+    public ApiResponse<TokenRefreshResponse> refreshToken(
+            @Valid @RequestBody TokenRefreshRequest request
+    ) {
+        return ApiResponse.ok(tokenRefreshService.refresh(request));
     }
 
     @Operation(

--- a/src/main/java/com/campost/backend/domain/auth/dto/TokenRefreshRequest.java
+++ b/src/main/java/com/campost/backend/domain/auth/dto/TokenRefreshRequest.java
@@ -1,0 +1,9 @@
+package com.campost.backend.domain.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record TokenRefreshRequest(
+        @NotBlank(message = "Refresh Token을 입력해주세요.")
+        String refreshToken
+) {
+}

--- a/src/main/java/com/campost/backend/domain/auth/dto/TokenRefreshResponse.java
+++ b/src/main/java/com/campost/backend/domain/auth/dto/TokenRefreshResponse.java
@@ -1,0 +1,11 @@
+package com.campost.backend.domain.auth.dto;
+
+public record TokenRefreshResponse(
+        String accessToken,
+        String tokenType,
+        long expiresIn
+) {
+    public static TokenRefreshResponse of(String accessToken, long expiresIn) {
+        return new TokenRefreshResponse(accessToken, "Bearer", expiresIn);
+    }
+}

--- a/src/main/java/com/campost/backend/domain/auth/service/TokenRefreshService.java
+++ b/src/main/java/com/campost/backend/domain/auth/service/TokenRefreshService.java
@@ -1,0 +1,56 @@
+package com.campost.backend.domain.auth.service;
+
+import com.campost.backend.domain.auth.dto.TokenRefreshRequest;
+import com.campost.backend.domain.auth.dto.TokenRefreshResponse;
+import com.campost.backend.domain.auth.model.User;
+import com.campost.backend.domain.auth.repository.UserRepository;
+import com.campost.backend.domain.user.exception.UserNotFoundException;
+import com.campost.backend.global.exception.InvalidTokenException;
+import com.campost.backend.global.jwt.JwtTokenService;
+import io.jsonwebtoken.Claims;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class TokenRefreshService {
+
+    private final UserRepository userRepository;
+    private final JwtTokenService jwtTokenService;
+
+    public TokenRefreshService(
+            UserRepository userRepository,
+            JwtTokenService jwtTokenService
+    ) {
+        this.userRepository = userRepository;
+        this.jwtTokenService = jwtTokenService;
+    }
+
+    @Transactional(readOnly = true)
+    public TokenRefreshResponse refresh(TokenRefreshRequest request) {
+        Claims claims = jwtTokenService.parse(request.refreshToken());
+
+        if (!JwtTokenService.REFRESH_TOKEN_TYPE.equals(claims.get("tokenType", String.class))) {
+            throw new InvalidTokenException("Invalid refresh token.");
+        }
+
+        long userId = parseUserId(claims.getSubject());
+        User user = userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
+        String accessToken = jwtTokenService.generateAccessToken(
+                user.id(),
+                user.username(),
+                user.name(),
+                user.role()
+        );
+
+        return TokenRefreshResponse.of(accessToken, jwtTokenService.accessTokenExpiryMs() / 1000);
+    }
+
+    private long parseUserId(String subject) {
+        try {
+            return Long.parseLong(subject);
+        } catch (NumberFormatException ex) {
+            throw new InvalidTokenException("Invalid token subject.");
+        }
+    }
+}

--- a/src/test/java/com/campost/backend/domain/auth/dto/TokenRefreshRequestValidationTest.java
+++ b/src/test/java/com/campost/backend/domain/auth/dto/TokenRefreshRequestValidationTest.java
@@ -1,0 +1,26 @@
+package com.campost.backend.domain.auth.dto;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TokenRefreshRequestValidationTest {
+
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+    @Test
+    void refreshTokenIsRequired() {
+        TokenRefreshRequest request = new TokenRefreshRequest("");
+
+        assertThat(validator.validate(request)).isNotEmpty();
+    }
+
+    @Test
+    void validRequestPassesValidation() {
+        TokenRefreshRequest request = new TokenRefreshRequest("refresh-token");
+
+        assertThat(validator.validate(request)).isEmpty();
+    }
+}

--- a/src/test/java/com/campost/backend/domain/auth/service/TokenRefreshServiceTest.java
+++ b/src/test/java/com/campost/backend/domain/auth/service/TokenRefreshServiceTest.java
@@ -1,0 +1,142 @@
+package com.campost.backend.domain.auth.service;
+
+import com.campost.backend.domain.auth.dto.TokenRefreshRequest;
+import com.campost.backend.domain.auth.dto.TokenRefreshResponse;
+import com.campost.backend.domain.auth.model.SignupUserCreateCommand;
+import com.campost.backend.domain.auth.model.User;
+import com.campost.backend.domain.auth.repository.UserRepository;
+import com.campost.backend.domain.user.exception.UserNotFoundException;
+import com.campost.backend.domain.user.model.UserOnboardingProfile;
+import com.campost.backend.domain.user.model.UserOnboardingProfileUpdateCommand;
+import com.campost.backend.domain.user.model.UserProfile;
+import com.campost.backend.domain.user.model.UserProfileUpdateCommand;
+import com.campost.backend.global.exception.InvalidTokenException;
+import com.campost.backend.global.jwt.JwtTokenService;
+import io.jsonwebtoken.Claims;
+import org.junit.jupiter.api.Test;
+
+import java.time.OffsetDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class TokenRefreshServiceTest {
+
+    private static final String JWT_SECRET = "01234567890123456789012345678901";
+    private static final long ACCESS_TOKEN_EXPIRY_MS = 3_600_000L;
+    private static final long REFRESH_TOKEN_EXPIRY_MS = 1_209_600_000L;
+
+    private final FakeUserRepository userRepository = new FakeUserRepository();
+    private final JwtTokenService jwtTokenService = new JwtTokenService(
+            JWT_SECRET,
+            ACCESS_TOKEN_EXPIRY_MS,
+            REFRESH_TOKEN_EXPIRY_MS
+    );
+    private final TokenRefreshService tokenRefreshService = new TokenRefreshService(
+            userRepository,
+            jwtTokenService
+    );
+
+    @Test
+    void refreshReturnsNewAccessTokenWithLatestUserInformation() {
+        userRepository.user = Optional.of(new User(
+                1L,
+                "campost123",
+                "Updated User",
+                "campost@example.com",
+                "password-hash",
+                "ADMIN",
+                OffsetDateTime.now()
+        ));
+        String refreshToken = jwtTokenService.generateRefreshToken(1L);
+
+        TokenRefreshResponse response = tokenRefreshService.refresh(new TokenRefreshRequest(refreshToken));
+
+        Claims accessClaims = jwtTokenService.parse(response.accessToken());
+        assertThat(response.tokenType()).isEqualTo("Bearer");
+        assertThat(response.expiresIn()).isEqualTo(ACCESS_TOKEN_EXPIRY_MS / 1000);
+        assertThat(accessClaims.getSubject()).isEqualTo("1");
+        assertThat(accessClaims.get("username", String.class)).isEqualTo("campost123");
+        assertThat(accessClaims.get("name", String.class)).isEqualTo("Updated User");
+        assertThat(accessClaims.get("role", String.class)).isEqualTo("ADMIN");
+        assertThat(accessClaims.get("tokenType", String.class)).isEqualTo(JwtTokenService.ACCESS_TOKEN_TYPE);
+    }
+
+    @Test
+    void refreshRejectsAccessToken() {
+        String accessToken = jwtTokenService.generateAccessToken(
+                1L,
+                "campost123",
+                "CamPost User",
+                "USER"
+        );
+
+        assertThatThrownBy(() -> tokenRefreshService.refresh(new TokenRefreshRequest(accessToken)))
+                .isInstanceOf(InvalidTokenException.class);
+    }
+
+    @Test
+    void refreshThrowsExceptionWhenUserDoesNotExist() {
+        userRepository.user = Optional.empty();
+        String refreshToken = jwtTokenService.generateRefreshToken(999L);
+
+        assertThatThrownBy(() -> tokenRefreshService.refresh(new TokenRefreshRequest(refreshToken)))
+                .isInstanceOf(UserNotFoundException.class);
+    }
+
+    private static class FakeUserRepository implements UserRepository {
+
+        private Optional<User> user = Optional.empty();
+
+        @Override
+        public User save(SignupUserCreateCommand command) {
+            throw new UnsupportedOperationException("Not used in this test.");
+        }
+
+        @Override
+        public boolean existsByEmail(String email) {
+            throw new UnsupportedOperationException("Not used in this test.");
+        }
+
+        @Override
+        public boolean existsByUsername(String username) {
+            throw new UnsupportedOperationException("Not used in this test.");
+        }
+
+        @Override
+        public Optional<User> findByUsername(String username) {
+            throw new UnsupportedOperationException("Not used in this test.");
+        }
+
+        @Override
+        public Optional<User> findById(long userId) {
+            return user;
+        }
+
+        @Override
+        public Optional<UserProfile> findProfileById(long userId) {
+            throw new UnsupportedOperationException("Not used in this test.");
+        }
+
+        @Override
+        public Optional<UserProfile> updateProfile(UserProfileUpdateCommand command) {
+            throw new UnsupportedOperationException("Not used in this test.");
+        }
+
+        @Override
+        public boolean updatePasswordHash(long userId, String passwordHash) {
+            throw new UnsupportedOperationException("Not used in this test.");
+        }
+
+        @Override
+        public boolean deleteById(long userId) {
+            throw new UnsupportedOperationException("Not used in this test.");
+        }
+
+        @Override
+        public Optional<UserOnboardingProfile> updateOnboardingProfile(UserOnboardingProfileUpdateCommand command) {
+            throw new UnsupportedOperationException("Not used in this test.");
+        }
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #65 

## 🏷️ PR 타입

- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)
- [ ] ⚙️ 프로젝트 초기 설정 (Chore)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🚨 PR 복구 (Revert)

## 📝 작업 내용

- Access Token 재발급 API 추가
  - `POST /api/v1/auth/token/refresh`
  - 요청 body: `{ refreshToken }`
  - 응답: 새 `accessToken`, `tokenType`, `expiresIn`

- Refresh Token 검증 로직 구현
  - JWT 서명/만료 검증
  - `tokenType`이 `refresh`인지 확인
  - Access Token으로 재발급 요청 시 `InvalidTokenException` 처리

- 최신 사용자 정보 기반 Access Token 재발급
  - Refresh Token에는 userId만 있으므로 subject에서 userId 추출
  - DB에서 최신 사용자 정보 조회
  - 최신 `username`, `name`, `role`로 새 Access Token 발급

- Swagger 문서 반영
  - 200, 400, 401, 404 응답 명세 추가

- 테스트 추가
  - Refresh Token 요청 DTO validation 테스트
  - 정상 재발급 테스트
  - Access Token으로 재발급 시도 시 실패 테스트
  - 존재하지 않는 사용자일 경우 실패 테스트
  
  ## 반영 내용

- Refresh Token subject 검증 보강
  - `subject == null`
  - `subject.isBlank()`
  - 위 케이스를 명시적으로 `InvalidTokenException`으로 처리
  - 내부 `NumberFormatException`에만 의존하지 않도록 개선

- 토큰 재발급 성공 ApiCode 추가
  - `AUTH200_TOKEN_REFRESH`
  - 메시지: `Access Token 재발급에 성공했습니다.`

- Refresh Token 재발급 API 응답 코드 일관성 개선
  - 기존: `ApiResponse.ok(result)`
  - 변경: `ApiResponse.ok(ApiCode.AUTH200_TOKEN_REFRESH, result)`

## 📸 스크린샷

- 테스트 결과를 스크린샷으로 첨부해주세요.

## ✅ 체크리스트

- [ ] 코드 리뷰를 받을 준비가 완료되었습니다.
- [ ] 코드 스타일 가이드를 준수했습니다.
- [ ] 셀프 리뷰를 완료했습니다.
- [ ] 테스트를 작성하고 모두 통과했습니다.
- [ ] 문서를 업데이트했습니다. (필요한 경우)

## 📎 기타 참고사항

- 논의가 필요한 부분, 리뷰 시 유의사항 등을 작성해주세요.
