### PR TITLE
refactor(#69) : 코드 리뷰 반영

### DIFF
--- a/src/main/java/com/campost/backend/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/campost/backend/domain/auth/controller/AuthController.java
@@ -108,7 +108,7 @@ public class AuthController {
     public ApiResponse<TokenRefreshResponse> refreshToken(
             @Valid @RequestBody TokenRefreshRequest request
     ) {
-        return ApiResponse.ok(tokenRefreshService.refresh(request));
+        return ApiResponse.ok(ApiCode.AUTH200_TOKEN_REFRESH, tokenRefreshService.refresh(request));
     }
 
     @Operation(

--- a/src/main/java/com/campost/backend/domain/auth/service/TokenRefreshService.java
+++ b/src/main/java/com/campost/backend/domain/auth/service/TokenRefreshService.java
@@ -47,6 +47,10 @@ public class TokenRefreshService {
     }
 
     private long parseUserId(String subject) {
+        if (subject == null || subject.isBlank()) {
+            throw new InvalidTokenException("Invalid token subject.");
+        }
+
         try {
             return Long.parseLong(subject);
         } catch (NumberFormatException ex) {

--- a/src/main/java/com/campost/backend/global/api/ApiCode.java
+++ b/src/main/java/com/campost/backend/global/api/ApiCode.java
@@ -3,6 +3,7 @@ package com.campost.backend.global.api;
 import org.springframework.http.HttpStatus;
 
 public enum ApiCode {
+    AUTH200_TOKEN_REFRESH(HttpStatus.OK, "AUTH200_TOKEN_REFRESH", "Access Token 재발급에 성공했습니다."),
     COMMON200(HttpStatus.OK, "COMMON200", "요청이 성공했습니다."),
     AUTH200_LOGIN(HttpStatus.OK, "AUTH200", "로그인에 성공했습니다."),
     AUTH201(HttpStatus.CREATED, "AUTH201", "회원가입 요청 형식 검증에 성공했습니다."),


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #69 

## 🏷️ PR 타입

- [ ] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [x] ♻️ 리팩토링 (Refactoring)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)
- [ ] ⚙️ 프로젝트 초기 설정 (Chore)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🚨 PR 복구 (Revert)

## 📝 작업 내용

## 반영 내용

- Refresh Token subject 방어 검증 추가
  - `subject == null`
  - `subject.isBlank()`
  - 위 경우 `InvalidTokenException` 발생
  - `Long.parseLong()` 내부 예외에만 의존하지 않도록 개선

- 토큰 재발급 성공 ApiCode 추가
  - `AUTH200_TOKEN_REFRESH`
  - 메시지: `Access Token 재발급에 성공했습니다.`

- Refresh Token 재발급 API 응답 코드 일관성 개선
  - 기존: `ApiResponse.ok(tokenRefreshService.refresh(request))`
  - 변경: `ApiResponse.ok(ApiCode.AUTH200_TOKEN_REFRESH, tokenRefreshService.refresh(request))`

## 📸 스크린샷

- 테스트 결과를 스크린샷으로 첨부해주세요.

## ✅ 체크리스트

- [ ] 코드 리뷰를 받을 준비가 완료되었습니다.
- [ ] 코드 스타일 가이드를 준수했습니다.
- [ ] 셀프 리뷰를 완료했습니다.
- [ ] 테스트를 작성하고 모두 통과했습니다.
- [ ] 문서를 업데이트했습니다. (필요한 경우)

## 📎 기타 참고사항

- 논의가 필요한 부분, 리뷰 시 유의사항 등을 작성해주세요.
