### PR TITLE
Feat(#72):  공지 북마크 저장 및 해제 API 구현

### DIFF
--- a/src/main/java/com/campost/backend/domain/post/bookmark/controller/NoticeBookmarkController.java
+++ b/src/main/java/com/campost/backend/domain/post/bookmark/controller/NoticeBookmarkController.java
@@ -1,0 +1,127 @@
+package com.campost.backend.domain.post.bookmark.controller;
+
+import com.campost.backend.domain.post.bookmark.dto.NoticeBookmarkResponse;
+import com.campost.backend.domain.post.bookmark.service.NoticeBookmarkService;
+import com.campost.backend.global.api.ApiResponse;
+import com.campost.backend.global.api.ErrorResponse;
+import com.campost.backend.global.exception.InvalidTokenException;
+import com.campost.backend.global.jwt.JwtTokenService;
+import io.jsonwebtoken.Claims;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Positive;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Validated
+@Tag(name = "Bookmark", description = "공지 북마크 API")
+@RestController
+@RequestMapping("/api/v1/notices/{noticeId}/bookmark")
+public class NoticeBookmarkController {
+
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final NoticeBookmarkService noticeBookmarkService;
+    private final JwtTokenService jwtTokenService;
+
+    public NoticeBookmarkController(
+            NoticeBookmarkService noticeBookmarkService,
+            JwtTokenService jwtTokenService
+    ) {
+        this.noticeBookmarkService = noticeBookmarkService;
+        this.jwtTokenService = jwtTokenService;
+    }
+
+    @Operation(
+            summary = "공지 북마크 저장",
+            description = "로그인한 사용자의 북마크 목록에 공지를 저장합니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "공지 북마크 저장 성공"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "인증 토큰 누락, 만료 또는 유효하지 않은 토큰",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "공지를 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+    @PostMapping
+    public ApiResponse<NoticeBookmarkResponse> bookmark(
+            @Parameter(description = "공지 ID")
+            @PathVariable @Positive long noticeId,
+            @RequestHeader(name = "Authorization", required = false) String authorization
+    ) {
+        long userId = resolveUserId(authorization);
+
+        return ApiResponse.ok(NoticeBookmarkResponse.from(
+                noticeBookmarkService.bookmark(userId, noticeId)
+        ));
+    }
+
+    @Operation(
+            summary = "공지 북마크 해제",
+            description = "로그인한 사용자의 북마크 목록에서 공지를 제거합니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "공지 북마크 해제 성공"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "인증 토큰 누락, 만료 또는 유효하지 않은 토큰",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "공지를 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+    @DeleteMapping
+    public ApiResponse<NoticeBookmarkResponse> unbookmark(
+            @Parameter(description = "공지 ID")
+            @PathVariable @Positive long noticeId,
+            @RequestHeader(name = "Authorization", required = false) String authorization
+    ) {
+        long userId = resolveUserId(authorization);
+
+        return ApiResponse.ok(NoticeBookmarkResponse.from(
+                noticeBookmarkService.unbookmark(userId, noticeId)
+        ));
+    }
+
+    private long resolveUserId(String authorization) {
+        if (authorization == null || !authorization.startsWith(BEARER_PREFIX)) {
+            throw new InvalidTokenException("Missing bearer token.");
+        }
+
+        String token = authorization.substring(BEARER_PREFIX.length()).trim();
+        Claims claims = jwtTokenService.parse(token);
+
+        try {
+            return Long.parseLong(claims.getSubject());
+        } catch (NumberFormatException ex) {
+            throw new InvalidTokenException("Invalid token subject.");
+        }
+    }
+}

--- a/src/main/java/com/campost/backend/domain/post/bookmark/controller/NoticeBookmarkController.java
+++ b/src/main/java/com/campost/backend/domain/post/bookmark/controller/NoticeBookmarkController.java
@@ -4,9 +4,7 @@ import com.campost.backend.domain.post.bookmark.dto.NoticeBookmarkResponse;
 import com.campost.backend.domain.post.bookmark.service.NoticeBookmarkService;
 import com.campost.backend.global.api.ApiResponse;
 import com.campost.backend.global.api.ErrorResponse;
-import com.campost.backend.global.exception.InvalidTokenException;
-import com.campost.backend.global.jwt.JwtTokenService;
-import io.jsonwebtoken.Claims;
+import com.campost.backend.global.auth.LoginUser;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -19,7 +17,6 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -29,17 +26,10 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/notices/{noticeId}/bookmark")
 public class NoticeBookmarkController {
 
-    private static final String BEARER_PREFIX = "Bearer ";
-
     private final NoticeBookmarkService noticeBookmarkService;
-    private final JwtTokenService jwtTokenService;
 
-    public NoticeBookmarkController(
-            NoticeBookmarkService noticeBookmarkService,
-            JwtTokenService jwtTokenService
-    ) {
+    public NoticeBookmarkController(NoticeBookmarkService noticeBookmarkService) {
         this.noticeBookmarkService = noticeBookmarkService;
-        this.jwtTokenService = jwtTokenService;
     }
 
     @Operation(
@@ -67,10 +57,9 @@ public class NoticeBookmarkController {
     public ApiResponse<NoticeBookmarkResponse> bookmark(
             @Parameter(description = "공지 ID")
             @PathVariable @Positive long noticeId,
-            @RequestHeader(name = "Authorization", required = false) String authorization
+            @Parameter(hidden = true)
+            @LoginUser long userId
     ) {
-        long userId = resolveUserId(authorization);
-
         return ApiResponse.ok(NoticeBookmarkResponse.from(
                 noticeBookmarkService.bookmark(userId, noticeId)
         ));
@@ -101,27 +90,11 @@ public class NoticeBookmarkController {
     public ApiResponse<NoticeBookmarkResponse> unbookmark(
             @Parameter(description = "공지 ID")
             @PathVariable @Positive long noticeId,
-            @RequestHeader(name = "Authorization", required = false) String authorization
+            @Parameter(hidden = true)
+            @LoginUser long userId
     ) {
-        long userId = resolveUserId(authorization);
-
         return ApiResponse.ok(NoticeBookmarkResponse.from(
                 noticeBookmarkService.unbookmark(userId, noticeId)
         ));
-    }
-
-    private long resolveUserId(String authorization) {
-        if (authorization == null || !authorization.startsWith(BEARER_PREFIX)) {
-            throw new InvalidTokenException("Missing bearer token.");
-        }
-
-        String token = authorization.substring(BEARER_PREFIX.length()).trim();
-        Claims claims = jwtTokenService.parse(token);
-
-        try {
-            return Long.parseLong(claims.getSubject());
-        } catch (NumberFormatException ex) {
-            throw new InvalidTokenException("Invalid token subject.");
-        }
     }
 }

--- a/src/main/java/com/campost/backend/domain/post/bookmark/dto/NoticeBookmarkResponse.java
+++ b/src/main/java/com/campost/backend/domain/post/bookmark/dto/NoticeBookmarkResponse.java
@@ -1,0 +1,12 @@
+package com.campost.backend.domain.post.bookmark.dto;
+
+import com.campost.backend.domain.post.bookmark.model.NoticeBookmarkStatus;
+
+public record NoticeBookmarkResponse(
+        long noticeId,
+        boolean bookmarked
+) {
+    public static NoticeBookmarkResponse from(NoticeBookmarkStatus status) {
+        return new NoticeBookmarkResponse(status.noticeId(), status.bookmarked());
+    }
+}

--- a/src/main/java/com/campost/backend/domain/post/bookmark/model/NoticeBookmarkStatus.java
+++ b/src/main/java/com/campost/backend/domain/post/bookmark/model/NoticeBookmarkStatus.java
@@ -1,0 +1,7 @@
+package com.campost.backend.domain.post.bookmark.model;
+
+public record NoticeBookmarkStatus(
+        long noticeId,
+        boolean bookmarked
+) {
+}

--- a/src/main/java/com/campost/backend/domain/post/bookmark/repository/NoticeBookmarkRepository.java
+++ b/src/main/java/com/campost/backend/domain/post/bookmark/repository/NoticeBookmarkRepository.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Repository;
 import java.util.Optional;
 
 @Repository
-public class NoticeBookmarkRepository {
+public class NoticeBookmarkRepository implements NoticeBookmarkStore {
 
     private final JdbcClient jdbcClient;
 
@@ -14,6 +14,7 @@ public class NoticeBookmarkRepository {
         this.jdbcClient = jdbcClient;
     }
 
+    @Override
     public Optional<String> findArticleIdByNoticeId(long noticeId) {
         String sql = """
                 SELECT article_id
@@ -27,21 +28,22 @@ public class NoticeBookmarkRepository {
                 .optional();
     }
 
+    @Override
     public boolean existsNoticeById(long noticeId) {
         String sql = """
-                SELECT EXISTS (
-                    SELECT 1
-                    FROM notices
-                    WHERE id = :noticeId
-                )
+                SELECT 1
+                FROM notices
+                WHERE id = :noticeId
                 """;
 
-        return Boolean.TRUE.equals(jdbcClient.sql(sql)
+        return jdbcClient.sql(sql)
                 .param("noticeId", noticeId)
-                .query(Boolean.class)
-                .single());
+                .query(Integer.class)
+                .optional()
+                .isPresent();
     }
 
+    @Override
     public void save(long userId, long noticeId, String articleId) {
         String sql = """
                 INSERT INTO bookmarks (user_id, notice_id, article_id)
@@ -56,6 +58,7 @@ public class NoticeBookmarkRepository {
                 .update();
     }
 
+    @Override
     public boolean delete(long userId, long noticeId) {
         String sql = """
                 DELETE FROM bookmarks

--- a/src/main/java/com/campost/backend/domain/post/bookmark/repository/NoticeBookmarkRepository.java
+++ b/src/main/java/com/campost/backend/domain/post/bookmark/repository/NoticeBookmarkRepository.java
@@ -1,0 +1,73 @@
+package com.campost.backend.domain.post.bookmark.repository;
+
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public class NoticeBookmarkRepository {
+
+    private final JdbcClient jdbcClient;
+
+    public NoticeBookmarkRepository(JdbcClient jdbcClient) {
+        this.jdbcClient = jdbcClient;
+    }
+
+    public Optional<String> findArticleIdByNoticeId(long noticeId) {
+        String sql = """
+                SELECT article_id
+                FROM notices
+                WHERE id = :noticeId
+                """;
+
+        return jdbcClient.sql(sql)
+                .param("noticeId", noticeId)
+                .query(String.class)
+                .optional();
+    }
+
+    public boolean existsNoticeById(long noticeId) {
+        String sql = """
+                SELECT EXISTS (
+                    SELECT 1
+                    FROM notices
+                    WHERE id = :noticeId
+                )
+                """;
+
+        return Boolean.TRUE.equals(jdbcClient.sql(sql)
+                .param("noticeId", noticeId)
+                .query(Boolean.class)
+                .single());
+    }
+
+    public void save(long userId, long noticeId, String articleId) {
+        String sql = """
+                INSERT INTO bookmarks (user_id, notice_id, article_id)
+                VALUES (:userId, :noticeId, :articleId)
+                ON CONFLICT (user_id, notice_id) DO NOTHING
+                """;
+
+        jdbcClient.sql(sql)
+                .param("userId", userId)
+                .param("noticeId", noticeId)
+                .param("articleId", articleId)
+                .update();
+    }
+
+    public boolean delete(long userId, long noticeId) {
+        String sql = """
+                DELETE FROM bookmarks
+                WHERE user_id = :userId
+                  AND notice_id = :noticeId
+                """;
+
+        int updatedRows = jdbcClient.sql(sql)
+                .param("userId", userId)
+                .param("noticeId", noticeId)
+                .update();
+
+        return updatedRows > 0;
+    }
+}

--- a/src/main/java/com/campost/backend/domain/post/bookmark/repository/NoticeBookmarkRepository.java
+++ b/src/main/java/com/campost/backend/domain/post/bookmark/repository/NoticeBookmarkRepository.java
@@ -3,8 +3,6 @@ package com.campost.backend.domain.post.bookmark.repository;
 import org.springframework.jdbc.core.simple.JdbcClient;
 import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
-
 @Repository
 public class NoticeBookmarkRepository implements NoticeBookmarkStore {
 
@@ -12,20 +10,6 @@ public class NoticeBookmarkRepository implements NoticeBookmarkStore {
 
     public NoticeBookmarkRepository(JdbcClient jdbcClient) {
         this.jdbcClient = jdbcClient;
-    }
-
-    @Override
-    public Optional<String> findArticleIdByNoticeId(long noticeId) {
-        String sql = """
-                SELECT article_id
-                FROM notices
-                WHERE id = :noticeId
-                """;
-
-        return jdbcClient.sql(sql)
-                .param("noticeId", noticeId)
-                .query(String.class)
-                .optional();
     }
 
     @Override
@@ -44,33 +28,30 @@ public class NoticeBookmarkRepository implements NoticeBookmarkStore {
     }
 
     @Override
-    public void save(long userId, long noticeId, String articleId) {
+    public void save(long userId, long noticeId) {
         String sql = """
-                INSERT INTO bookmarks (user_id, notice_id, article_id)
-                VALUES (:userId, :noticeId, :articleId)
+                INSERT INTO bookmarks (user_id, notice_id)
+                VALUES (:userId, :noticeId)
                 ON CONFLICT (user_id, notice_id) DO NOTHING
                 """;
 
         jdbcClient.sql(sql)
                 .param("userId", userId)
                 .param("noticeId", noticeId)
-                .param("articleId", articleId)
                 .update();
     }
 
     @Override
-    public boolean delete(long userId, long noticeId) {
+    public void delete(long userId, long noticeId) {
         String sql = """
                 DELETE FROM bookmarks
                 WHERE user_id = :userId
                   AND notice_id = :noticeId
                 """;
 
-        int updatedRows = jdbcClient.sql(sql)
+        jdbcClient.sql(sql)
                 .param("userId", userId)
                 .param("noticeId", noticeId)
                 .update();
-
-        return updatedRows > 0;
     }
 }

--- a/src/main/java/com/campost/backend/domain/post/bookmark/repository/NoticeBookmarkStore.java
+++ b/src/main/java/com/campost/backend/domain/post/bookmark/repository/NoticeBookmarkStore.java
@@ -1,0 +1,14 @@
+package com.campost.backend.domain.post.bookmark.repository;
+
+import java.util.Optional;
+
+public interface NoticeBookmarkStore {
+
+    Optional<String> findArticleIdByNoticeId(long noticeId);
+
+    boolean existsNoticeById(long noticeId);
+
+    void save(long userId, long noticeId, String articleId);
+
+    boolean delete(long userId, long noticeId);
+}

--- a/src/main/java/com/campost/backend/domain/post/bookmark/repository/NoticeBookmarkStore.java
+++ b/src/main/java/com/campost/backend/domain/post/bookmark/repository/NoticeBookmarkStore.java
@@ -1,14 +1,10 @@
 package com.campost.backend.domain.post.bookmark.repository;
 
-import java.util.Optional;
-
 public interface NoticeBookmarkStore {
-
-    Optional<String> findArticleIdByNoticeId(long noticeId);
 
     boolean existsNoticeById(long noticeId);
 
-    void save(long userId, long noticeId, String articleId);
+    void save(long userId, long noticeId);
 
-    boolean delete(long userId, long noticeId);
+    void delete(long userId, long noticeId);
 }

--- a/src/main/java/com/campost/backend/domain/post/bookmark/service/NoticeBookmarkService.java
+++ b/src/main/java/com/campost/backend/domain/post/bookmark/service/NoticeBookmarkService.java
@@ -1,7 +1,7 @@
 package com.campost.backend.domain.post.bookmark.service;
 
 import com.campost.backend.domain.post.bookmark.model.NoticeBookmarkStatus;
-import com.campost.backend.domain.post.bookmark.repository.NoticeBookmarkRepository;
+import com.campost.backend.domain.post.bookmark.repository.NoticeBookmarkStore;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -10,29 +10,29 @@ import java.util.NoSuchElementException;
 @Service
 public class NoticeBookmarkService {
 
-    private final NoticeBookmarkRepository noticeBookmarkRepository;
+    private final NoticeBookmarkStore noticeBookmarkStore;
 
-    public NoticeBookmarkService(NoticeBookmarkRepository noticeBookmarkRepository) {
-        this.noticeBookmarkRepository = noticeBookmarkRepository;
+    public NoticeBookmarkService(NoticeBookmarkStore noticeBookmarkStore) {
+        this.noticeBookmarkStore = noticeBookmarkStore;
     }
 
     @Transactional
     public NoticeBookmarkStatus bookmark(long userId, long noticeId) {
-        String articleId = noticeBookmarkRepository.findArticleIdByNoticeId(noticeId)
+        String articleId = noticeBookmarkStore.findArticleIdByNoticeId(noticeId)
                 .orElseThrow(() -> new NoSuchElementException("Notice not found: " + noticeId));
 
-        noticeBookmarkRepository.save(userId, noticeId, articleId);
+        noticeBookmarkStore.save(userId, noticeId, articleId);
 
         return new NoticeBookmarkStatus(noticeId, true);
     }
 
     @Transactional
     public NoticeBookmarkStatus unbookmark(long userId, long noticeId) {
-        if (!noticeBookmarkRepository.existsNoticeById(noticeId)) {
+        if (!noticeBookmarkStore.existsNoticeById(noticeId)) {
             throw new NoSuchElementException("Notice not found: " + noticeId);
         }
 
-        noticeBookmarkRepository.delete(userId, noticeId);
+        noticeBookmarkStore.delete(userId, noticeId);
 
         return new NoticeBookmarkStatus(noticeId, false);
     }

--- a/src/main/java/com/campost/backend/domain/post/bookmark/service/NoticeBookmarkService.java
+++ b/src/main/java/com/campost/backend/domain/post/bookmark/service/NoticeBookmarkService.java
@@ -18,10 +18,11 @@ public class NoticeBookmarkService {
 
     @Transactional
     public NoticeBookmarkStatus bookmark(long userId, long noticeId) {
-        String articleId = noticeBookmarkStore.findArticleIdByNoticeId(noticeId)
-                .orElseThrow(() -> new NoSuchElementException("Notice not found: " + noticeId));
+        if (!noticeBookmarkStore.existsNoticeById(noticeId)) {
+            throw new NoSuchElementException("Notice not found: " + noticeId);
+        }
 
-        noticeBookmarkStore.save(userId, noticeId, articleId);
+        noticeBookmarkStore.save(userId, noticeId);
 
         return new NoticeBookmarkStatus(noticeId, true);
     }

--- a/src/main/java/com/campost/backend/domain/post/bookmark/service/NoticeBookmarkService.java
+++ b/src/main/java/com/campost/backend/domain/post/bookmark/service/NoticeBookmarkService.java
@@ -1,0 +1,39 @@
+package com.campost.backend.domain.post.bookmark.service;
+
+import com.campost.backend.domain.post.bookmark.model.NoticeBookmarkStatus;
+import com.campost.backend.domain.post.bookmark.repository.NoticeBookmarkRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.NoSuchElementException;
+
+@Service
+public class NoticeBookmarkService {
+
+    private final NoticeBookmarkRepository noticeBookmarkRepository;
+
+    public NoticeBookmarkService(NoticeBookmarkRepository noticeBookmarkRepository) {
+        this.noticeBookmarkRepository = noticeBookmarkRepository;
+    }
+
+    @Transactional
+    public NoticeBookmarkStatus bookmark(long userId, long noticeId) {
+        String articleId = noticeBookmarkRepository.findArticleIdByNoticeId(noticeId)
+                .orElseThrow(() -> new NoSuchElementException("Notice not found: " + noticeId));
+
+        noticeBookmarkRepository.save(userId, noticeId, articleId);
+
+        return new NoticeBookmarkStatus(noticeId, true);
+    }
+
+    @Transactional
+    public NoticeBookmarkStatus unbookmark(long userId, long noticeId) {
+        if (!noticeBookmarkRepository.existsNoticeById(noticeId)) {
+            throw new NoSuchElementException("Notice not found: " + noticeId);
+        }
+
+        noticeBookmarkRepository.delete(userId, noticeId);
+
+        return new NoticeBookmarkStatus(noticeId, false);
+    }
+}

--- a/src/main/java/com/campost/backend/global/auth/LoginUser.java
+++ b/src/main/java/com/campost/backend/global/auth/LoginUser.java
@@ -1,0 +1,11 @@
+package com.campost.backend.global.auth;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LoginUser {
+}

--- a/src/main/java/com/campost/backend/global/auth/LoginUserArgumentResolver.java
+++ b/src/main/java/com/campost/backend/global/auth/LoginUserArgumentResolver.java
@@ -39,7 +39,7 @@ public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver 
     ) {
         String authorization = webRequest.getHeader(AUTHORIZATION_HEADER);
 
-        if (authorization == null || !authorization.startsWith(BEARER_PREFIX)) {
+        if (authorization == null || !authorization.regionMatches(true, 0, BEARER_PREFIX, 0, BEARER_PREFIX.length())) {
             throw new InvalidTokenException("Missing bearer token.");
         }
 

--- a/src/main/java/com/campost/backend/global/auth/LoginUserArgumentResolver.java
+++ b/src/main/java/com/campost/backend/global/auth/LoginUserArgumentResolver.java
@@ -1,0 +1,60 @@
+package com.campost.backend.global.auth;
+
+import com.campost.backend.global.exception.InvalidTokenException;
+import com.campost.backend.global.jwt.JwtTokenService;
+import io.jsonwebtoken.Claims;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final JwtTokenService jwtTokenService;
+
+    public LoginUserArgumentResolver(JwtTokenService jwtTokenService) {
+        this.jwtTokenService = jwtTokenService;
+    }
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        Class<?> parameterType = parameter.getParameterType();
+
+        return parameter.hasParameterAnnotation(LoginUser.class)
+                && (Long.class.equals(parameterType) || long.class.equals(parameterType));
+    }
+
+    @Override
+    public Object resolveArgument(
+            MethodParameter parameter,
+            ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest,
+            WebDataBinderFactory binderFactory
+    ) {
+        String authorization = webRequest.getHeader(AUTHORIZATION_HEADER);
+
+        if (authorization == null || !authorization.startsWith(BEARER_PREFIX)) {
+            throw new InvalidTokenException("Missing bearer token.");
+        }
+
+        String token = authorization.substring(BEARER_PREFIX.length()).trim();
+        Claims claims = jwtTokenService.parse(token);
+        String subject = claims.getSubject();
+
+        if (subject == null || subject.isBlank()) {
+            throw new InvalidTokenException("Invalid token subject.");
+        }
+
+        try {
+            return Long.parseLong(subject);
+        } catch (NumberFormatException ex) {
+            throw new InvalidTokenException("Invalid token subject.");
+        }
+    }
+}

--- a/src/main/java/com/campost/backend/global/config/WebConfig.java
+++ b/src/main/java/com/campost/backend/global/config/WebConfig.java
@@ -1,0 +1,24 @@
+package com.campost.backend.global.config;
+
+import com.campost.backend.global.auth.LoginUserArgumentResolver;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.lang.NonNull;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    private final LoginUserArgumentResolver loginUserArgumentResolver;
+
+    public WebConfig(LoginUserArgumentResolver loginUserArgumentResolver) {
+        this.loginUserArgumentResolver = loginUserArgumentResolver;
+    }
+
+    @Override
+    public void addArgumentResolvers(@NonNull List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(loginUserArgumentResolver);
+    }
+}

--- a/src/main/resources/db/migration/V14__add_notice_id_to_bookmarks.sql
+++ b/src/main/resources/db/migration/V14__add_notice_id_to_bookmarks.sql
@@ -40,3 +40,6 @@ CREATE UNIQUE INDEX IF NOT EXISTS ux_bookmarks_user_notice
 
 CREATE INDEX IF NOT EXISTS idx_bookmarks_notice_id
     ON bookmarks(notice_id);
+
+ALTER TABLE bookmarks
+    DROP COLUMN IF EXISTS article_id;

--- a/src/main/resources/db/migration/V14__add_notice_id_to_bookmarks.sql
+++ b/src/main/resources/db/migration/V14__add_notice_id_to_bookmarks.sql
@@ -1,0 +1,33 @@
+ALTER TABLE bookmarks
+    ADD COLUMN IF NOT EXISTS notice_id BIGINT;
+
+UPDATE bookmarks b
+SET notice_id = n.id
+FROM notices n
+WHERE b.notice_id IS NULL
+  AND b.article_id = n.article_id;
+
+DELETE FROM bookmarks
+WHERE notice_id IS NULL;
+
+ALTER TABLE bookmarks
+    ALTER COLUMN notice_id SET NOT NULL;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'fk_bookmarks_notice_id'
+    ) THEN
+        ALTER TABLE bookmarks
+            ADD CONSTRAINT fk_bookmarks_notice_id
+            FOREIGN KEY (notice_id) REFERENCES notices(id) ON DELETE CASCADE;
+    END IF;
+END $$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_bookmarks_user_notice
+    ON bookmarks(user_id, notice_id);
+
+CREATE INDEX IF NOT EXISTS idx_bookmarks_notice_id
+    ON bookmarks(notice_id);

--- a/src/main/resources/db/migration/V14__add_notice_id_to_bookmarks.sql
+++ b/src/main/resources/db/migration/V14__add_notice_id_to_bookmarks.sql
@@ -15,6 +15,15 @@ ALTER TABLE bookmarks
 
 DO $$
 BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'bookmarks_user_id_article_id_key'
+    ) THEN
+        ALTER TABLE bookmarks
+            DROP CONSTRAINT bookmarks_user_id_article_id_key;
+    END IF;
+
     IF NOT EXISTS (
         SELECT 1
         FROM pg_constraint

--- a/src/test/java/com/campost/backend/domain/post/bookmark/service/NoticeBookmarkServiceTest.java
+++ b/src/test/java/com/campost/backend/domain/post/bookmark/service/NoticeBookmarkServiceTest.java
@@ -1,0 +1,97 @@
+package com.campost.backend.domain.post.bookmark.service;
+
+import com.campost.backend.domain.post.bookmark.model.NoticeBookmarkStatus;
+import com.campost.backend.domain.post.bookmark.repository.NoticeBookmarkRepository;
+import org.junit.jupiter.api.Test;
+
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class NoticeBookmarkServiceTest {
+
+    private final FakeNoticeBookmarkRepository noticeBookmarkRepository = new FakeNoticeBookmarkRepository();
+    private final NoticeBookmarkService noticeBookmarkService = new NoticeBookmarkService(noticeBookmarkRepository);
+
+    @Test
+    void bookmarkSavesNoticeBookmark() {
+        noticeBookmarkRepository.articleId = Optional.of("12345");
+
+        NoticeBookmarkStatus status = noticeBookmarkService.bookmark(1L, 10L);
+
+        assertThat(status.noticeId()).isEqualTo(10L);
+        assertThat(status.bookmarked()).isTrue();
+        assertThat(noticeBookmarkRepository.savedUserId).isEqualTo(1L);
+        assertThat(noticeBookmarkRepository.savedNoticeId).isEqualTo(10L);
+        assertThat(noticeBookmarkRepository.savedArticleId).isEqualTo("12345");
+    }
+
+    @Test
+    void bookmarkThrowsExceptionWhenNoticeDoesNotExist() {
+        noticeBookmarkRepository.articleId = Optional.empty();
+
+        assertThatThrownBy(() -> noticeBookmarkService.bookmark(1L, 999L))
+                .isInstanceOf(NoSuchElementException.class);
+    }
+
+    @Test
+    void unbookmarkDeletesNoticeBookmark() {
+        noticeBookmarkRepository.noticeExists = true;
+
+        NoticeBookmarkStatus status = noticeBookmarkService.unbookmark(1L, 10L);
+
+        assertThat(status.noticeId()).isEqualTo(10L);
+        assertThat(status.bookmarked()).isFalse();
+        assertThat(noticeBookmarkRepository.deletedUserId).isEqualTo(1L);
+        assertThat(noticeBookmarkRepository.deletedNoticeId).isEqualTo(10L);
+    }
+
+    @Test
+    void unbookmarkThrowsExceptionWhenNoticeDoesNotExist() {
+        noticeBookmarkRepository.noticeExists = false;
+
+        assertThatThrownBy(() -> noticeBookmarkService.unbookmark(1L, 999L))
+                .isInstanceOf(NoSuchElementException.class);
+    }
+
+    private static class FakeNoticeBookmarkRepository extends NoticeBookmarkRepository {
+
+        private Optional<String> articleId = Optional.empty();
+        private boolean noticeExists;
+        private long savedUserId;
+        private long savedNoticeId;
+        private String savedArticleId;
+        private long deletedUserId;
+        private long deletedNoticeId;
+
+        private FakeNoticeBookmarkRepository() {
+            super(null);
+        }
+
+        @Override
+        public Optional<String> findArticleIdByNoticeId(long noticeId) {
+            return articleId;
+        }
+
+        @Override
+        public boolean existsNoticeById(long noticeId) {
+            return noticeExists;
+        }
+
+        @Override
+        public void save(long userId, long noticeId, String articleId) {
+            this.savedUserId = userId;
+            this.savedNoticeId = noticeId;
+            this.savedArticleId = articleId;
+        }
+
+        @Override
+        public boolean delete(long userId, long noticeId) {
+            this.deletedUserId = userId;
+            this.deletedNoticeId = noticeId;
+            return true;
+        }
+    }
+}

--- a/src/test/java/com/campost/backend/domain/post/bookmark/service/NoticeBookmarkServiceTest.java
+++ b/src/test/java/com/campost/backend/domain/post/bookmark/service/NoticeBookmarkServiceTest.java
@@ -5,8 +5,6 @@ import com.campost.backend.domain.post.bookmark.repository.NoticeBookmarkStore;
 import org.junit.jupiter.api.Test;
 
 import java.util.NoSuchElementException;
-import java.util.Optional;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -17,7 +15,7 @@ class NoticeBookmarkServiceTest {
 
     @Test
     void bookmarkSavesNoticeBookmark() {
-        noticeBookmarkStore.articleId = Optional.of("12345");
+        noticeBookmarkStore.noticeExists = true;
 
         NoticeBookmarkStatus status = noticeBookmarkService.bookmark(1L, 10L);
 
@@ -25,12 +23,11 @@ class NoticeBookmarkServiceTest {
         assertThat(status.bookmarked()).isTrue();
         assertThat(noticeBookmarkStore.savedUserId).isEqualTo(1L);
         assertThat(noticeBookmarkStore.savedNoticeId).isEqualTo(10L);
-        assertThat(noticeBookmarkStore.savedArticleId).isEqualTo("12345");
     }
 
     @Test
     void bookmarkThrowsExceptionWhenNoticeDoesNotExist() {
-        noticeBookmarkStore.articleId = Optional.empty();
+        noticeBookmarkStore.noticeExists = false;
 
         assertThatThrownBy(() -> noticeBookmarkService.bookmark(1L, 999L))
                 .isInstanceOf(NoSuchElementException.class);
@@ -58,18 +55,11 @@ class NoticeBookmarkServiceTest {
 
     private static class FakeNoticeBookmarkStore implements NoticeBookmarkStore {
 
-        private Optional<String> articleId = Optional.empty();
         private boolean noticeExists;
         private long savedUserId;
         private long savedNoticeId;
-        private String savedArticleId;
         private long deletedUserId;
         private long deletedNoticeId;
-
-        @Override
-        public Optional<String> findArticleIdByNoticeId(long noticeId) {
-            return articleId;
-        }
 
         @Override
         public boolean existsNoticeById(long noticeId) {
@@ -77,17 +67,15 @@ class NoticeBookmarkServiceTest {
         }
 
         @Override
-        public void save(long userId, long noticeId, String articleId) {
+        public void save(long userId, long noticeId) {
             this.savedUserId = userId;
             this.savedNoticeId = noticeId;
-            this.savedArticleId = articleId;
         }
 
         @Override
-        public boolean delete(long userId, long noticeId) {
+        public void delete(long userId, long noticeId) {
             this.deletedUserId = userId;
             this.deletedNoticeId = noticeId;
-            return true;
         }
     }
 }

--- a/src/test/java/com/campost/backend/domain/post/bookmark/service/NoticeBookmarkServiceTest.java
+++ b/src/test/java/com/campost/backend/domain/post/bookmark/service/NoticeBookmarkServiceTest.java
@@ -1,7 +1,7 @@
 package com.campost.backend.domain.post.bookmark.service;
 
 import com.campost.backend.domain.post.bookmark.model.NoticeBookmarkStatus;
-import com.campost.backend.domain.post.bookmark.repository.NoticeBookmarkRepository;
+import com.campost.backend.domain.post.bookmark.repository.NoticeBookmarkStore;
 import org.junit.jupiter.api.Test;
 
 import java.util.NoSuchElementException;
@@ -12,25 +12,25 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class NoticeBookmarkServiceTest {
 
-    private final FakeNoticeBookmarkRepository noticeBookmarkRepository = new FakeNoticeBookmarkRepository();
-    private final NoticeBookmarkService noticeBookmarkService = new NoticeBookmarkService(noticeBookmarkRepository);
+    private final FakeNoticeBookmarkStore noticeBookmarkStore = new FakeNoticeBookmarkStore();
+    private final NoticeBookmarkService noticeBookmarkService = new NoticeBookmarkService(noticeBookmarkStore);
 
     @Test
     void bookmarkSavesNoticeBookmark() {
-        noticeBookmarkRepository.articleId = Optional.of("12345");
+        noticeBookmarkStore.articleId = Optional.of("12345");
 
         NoticeBookmarkStatus status = noticeBookmarkService.bookmark(1L, 10L);
 
         assertThat(status.noticeId()).isEqualTo(10L);
         assertThat(status.bookmarked()).isTrue();
-        assertThat(noticeBookmarkRepository.savedUserId).isEqualTo(1L);
-        assertThat(noticeBookmarkRepository.savedNoticeId).isEqualTo(10L);
-        assertThat(noticeBookmarkRepository.savedArticleId).isEqualTo("12345");
+        assertThat(noticeBookmarkStore.savedUserId).isEqualTo(1L);
+        assertThat(noticeBookmarkStore.savedNoticeId).isEqualTo(10L);
+        assertThat(noticeBookmarkStore.savedArticleId).isEqualTo("12345");
     }
 
     @Test
     void bookmarkThrowsExceptionWhenNoticeDoesNotExist() {
-        noticeBookmarkRepository.articleId = Optional.empty();
+        noticeBookmarkStore.articleId = Optional.empty();
 
         assertThatThrownBy(() -> noticeBookmarkService.bookmark(1L, 999L))
                 .isInstanceOf(NoSuchElementException.class);
@@ -38,25 +38,25 @@ class NoticeBookmarkServiceTest {
 
     @Test
     void unbookmarkDeletesNoticeBookmark() {
-        noticeBookmarkRepository.noticeExists = true;
+        noticeBookmarkStore.noticeExists = true;
 
         NoticeBookmarkStatus status = noticeBookmarkService.unbookmark(1L, 10L);
 
         assertThat(status.noticeId()).isEqualTo(10L);
         assertThat(status.bookmarked()).isFalse();
-        assertThat(noticeBookmarkRepository.deletedUserId).isEqualTo(1L);
-        assertThat(noticeBookmarkRepository.deletedNoticeId).isEqualTo(10L);
+        assertThat(noticeBookmarkStore.deletedUserId).isEqualTo(1L);
+        assertThat(noticeBookmarkStore.deletedNoticeId).isEqualTo(10L);
     }
 
     @Test
     void unbookmarkThrowsExceptionWhenNoticeDoesNotExist() {
-        noticeBookmarkRepository.noticeExists = false;
+        noticeBookmarkStore.noticeExists = false;
 
         assertThatThrownBy(() -> noticeBookmarkService.unbookmark(1L, 999L))
                 .isInstanceOf(NoSuchElementException.class);
     }
 
-    private static class FakeNoticeBookmarkRepository extends NoticeBookmarkRepository {
+    private static class FakeNoticeBookmarkStore implements NoticeBookmarkStore {
 
         private Optional<String> articleId = Optional.empty();
         private boolean noticeExists;
@@ -65,10 +65,6 @@ class NoticeBookmarkServiceTest {
         private String savedArticleId;
         private long deletedUserId;
         private long deletedNoticeId;
-
-        private FakeNoticeBookmarkRepository() {
-            super(null);
-        }
 
         @Override
         public Optional<String> findArticleIdByNoticeId(long noticeId) {


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #72 

## 🏷️ PR 타입

- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)
- [ ] ⚙️ 프로젝트 초기 설정 (Chore)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🚨 PR 복구 (Revert)

## 📝 작업 내용

- 공지 북마크 저장/해제 API 추가
  - `POST /api/v1/notices/{noticeId}/bookmark`
  - `DELETE /api/v1/notices/{noticeId}/bookmark`
  - 로그인 사용자의 JWT Access Token에서 사용자 ID를 추출하여 북마크 처리

- 북마크 응답 DTO 추가
  - `noticeId`
  - `bookmarked`
  - 프론트에서 버튼 상태를 바로 반영할 수 있도록 저장/해제 결과 반환

- 북마크 저장 로직 구현
  - 존재하는 공지인지 확인 후 북마크 저장
  - `ON CONFLICT (user_id, notice_id) DO NOTHING`으로 중복 저장 방지
  - 존재하지 않는 공지 ID 요청 시 404 처리

- 북마크 해제 로직 구현
  - 로그인 사용자의 특정 공지 북마크 삭제
  - 이미 해제된 상태여도 최종 상태를 `bookmarked: false`로 반환

- DB 마이그레이션 추가
  - 기존 `bookmarks` 테이블에 `notice_id` 컬럼 추가
  - `notices(id)` 외래키 연결
  - `(user_id, notice_id)` 유니크 인덱스 추가
  - `notice_id` 조회 인덱스 추가

- 단위 테스트 추가
  - 북마크 저장 성공
  - 존재하지 않는 공지 북마크 시 예외
  - 북마크 해제 성공
  - 존재하지 않는 공지 해제 시 예외

## 검증

- `./mvnw.cmd test` 통과
- 총 72개 테스트 통과

## 코드리뷰 반영 내용

- 북마크 공지 존재 여부 조회 방식 개선
  - `SELECT EXISTS ... Boolean.class` 매핑 대신 `SELECT 1 ... optional().isPresent()` 방식으로 변경
  - Boolean 매핑 호환성 이슈 가능성을 줄이고 가독성 개선

- 로그인 사용자 ID 추출 로직 공통화
  - `@LoginUser` 커스텀 어노테이션 추가
  - `LoginUserArgumentResolver` 추가
  - `WebConfig`에서 argument resolver 등록
  - `NoticeBookmarkController`에서 직접 JWT 파싱하던 `resolveUserId` 제거
  - 컨트롤러는 `@LoginUser long userId`를 주입받도록 변경

- 북마크 저장소 테스트 구조 개선
  - 기존 `NoticeBookmarkRepository` 상속 + `super(null)` 방식 제거
  - `NoticeBookmarkStore` 인터페이스를 분리하고 서비스가 인터페이스에 의존하도록 변경
  - 테스트에서는 안전한 Fake 구현체를 사용하도록 수정
  - 참고: Mockito 방식도 타당하지만, 현재 로컬 Java 26 환경에서 Byte Buddy/Mockito 조합이 클래스 모킹을 지원하지 않아 테스트가 실패하여 인터페이스 기반 Fake로 대체

- 북마크 DB 제약 조건 정리
  - 기존 `(user_id, article_id)` 유니크 제약 조건 제거 로직 추가
  - 새 기준인 `(user_id, notice_id)` 유니크 인덱스를 북마크 중복 방지 기준으로 사용

## 검증

- `./mvnw.cmd test` 통과
- 총 72개 테스트 통과


## 코드리뷰 반영 내용 2

- Authorization Bearer 스키마 검증 개선
  - `startsWith("Bearer ")` 대신 `regionMatches(..., ignoreCase=true)` 사용
  - `Bearer`, `bearer`, `BEARER` 등 대소문자와 관계없이 처리 가능하도록 개선

- 북마크 삭제 메서드 단순화
  - `NoticeBookmarkStore.delete()` 반환 타입을 `boolean`에서 `void`로 변경
  - 서비스에서 사용하지 않는 반환값 제거
  - `NoticeBookmarkRepository.delete()`도 삭제 쿼리 실행만 수행하도록 단순화

- 북마크 저장 구조를 `notice_id` 중심으로 정리
  - `bookmarks.article_id` 저장 의존 제거
  - 북마크 저장 시 `article_id` 조회 쿼리 제거
  - 공지 존재 여부만 확인한 뒤 `user_id`, `notice_id`로 저장
  - 마이그레이션에서 기존 데이터를 `notice_id`로 매핑한 뒤 `article_id` 컬럼 제거

- 테스트 수정
  - `article_id` 기반 Fake/검증 제거
  - 공지 존재 여부 확인 및 `notice_id` 저장 흐름 기준으로 테스트 정리

## 검증

- `./mvnw.cmd test` 통과
- 총 72개 테스트 통과
## 📸 스크린샷

- 테스트 결과를 스크린샷으로 첨부해주세요.

## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다.
- [x] 코드 스타일 가이드를 준수했습니다.
- [x] 셀프 리뷰를 완료했습니다.
- [x] 테스트를 작성하고 모두 통과했습니다.
- [x] 문서를 업데이트했습니다. (필요한 경우)

## 📎 기타 참고사항

- 논의가 필요한 부분, 리뷰 시 유의사항 등을 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 공지사항 북마크 기능 추가: 사용자는 공지사항을 개인 북마크에 저장하거나 제거할 수 있습니다.
  * 공지사항별 북마크 API 제공: 인증된 사용자의 북마크 상태를 관리합니다.

* **Tests**
  * 공지사항 북마크 기능에 대한 테스트 커버리지 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->