### PR TITLE
Chore(#75): .env 단일화 및 Neon 기반 로컬 개발 환경 전환

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,49 +3,35 @@
 # cp .env.example .env   (Windows: copy .env.example .env)
 # ============================================================
 
-# ── PostgreSQL ───────────────────────────────────────────────
-POSTGRES_DB=campost
-POSTGRES_USER=campost
-POSTGRES_PASSWORD=<REQUIRED>
-DATABASE_URL=<REQUIRED>
-
-# ── Spring Boot ──────────────────────────────────────────────
-SPRING_DATASOURCE_URL=<REQUIRED>
+# ── Neon PostgreSQL (기본 로컬 개발 및 배포 공용) ────────────
+# Neon Dashboard > Connection Details > Pooled connection string 사용
+# Direct connection string은 사용하지 않습니다.
+SPRING_DATASOURCE_URL=jdbc:postgresql://<neon-pooler-host>/neondb?sslmode=require
 SPRING_DATASOURCE_USERNAME=<REQUIRED>
 SPRING_DATASOURCE_PASSWORD=<REQUIRED>
-APP_CORS_ALLOWED_ORIGINS=<REQUIRED>
+
+# ── Spring Boot ──────────────────────────────────────────────
+APP_CORS_ALLOWED_ORIGINS=http://localhost:5173,http://localhost:3000
 JWT_SECRET=<REQUIRED>
-JWT_EXPIRY_MS=<REQUIRED>
+JWT_EXPIRY_MS=3600000
 
-# Development email verification
-# Mailpit Web UI: http://localhost:8025
-# Mailpit SMTP host inside Docker Compose: mailpit:1025
-APP_MAIL_VERIFICATION_SENDER=smtp
-APP_MAIL_FROM=no-reply@campost.local
-SPRING_MAIL_HOST=mailpit
-SPRING_MAIL_PORT=1025
-SPRING_MAIL_USERNAME=
-SPRING_MAIL_PASSWORD=
-SPRING_MAIL_PROPERTIES_MAIL_SMTP_AUTH=false
-SPRING_MAIL_PROPERTIES_MAIL_SMTP_STARTTLS_ENABLE=false
+# ── 메일 인증 ────────────────────────────────────────────────
+# 로컬: logging (실제 메일 발송 없이 콘솔 출력)
+# 운영: smtp (별도 SMTP 설정 필요)
+APP_MAIL_VERIFICATION_SENDER=logging
 
-# ── Python Crawler ───────────────────────────────────────────
-OUTPUT_DIR=./data
-CRAWL_INTERVAL_MINUTES=60
-HEADLESS=true
-
-# ── AI Worker (Sprint 2에서 실제 키 입력) ────────────────────
-OPENAI_API_KEY=sk-your-openai-api-key-here
-AI_MODEL=gpt-4o-mini
-AI_MOCK=true          # true: Mock 응답 사용 / false: 실제 OpenAI 호출
-
-# ── Raw JSON 저장소 경로 (컨테이너 공유 볼륨) ────────────────
-RAW_STORE_DIR=/data/raw
-AI_RESULT_DIR=/data/ai_results
-FILES_DIR=/data/files
-
-# ── Importer (Raw JSON -> DB) ───────────────────────────────
-IMPORTER_ENABLED=true
+# ── Importer (Raw JSON → DB) ─────────────────────────────────
+# 로컬에서 importer 실행 시 true로 변경, Render 배포는 false 유지
+IMPORTER_ENABLED=false
 IMPORTER_INITIAL_DELAY_MS=5000
 IMPORTER_FIXED_DELAY_MS=30000
 IMPORTER_BATCH_SIZE=100
+
+# ── AI Mock ──────────────────────────────────────────────────
+AI_MOCK=true
+
+# ── Docker PostgreSQL (선택, 마이그레이션/초기화 테스트용) ───
+# Neon 사용 시 아래 값은 사용되지 않습니다.
+POSTGRES_DB=campost
+POSTGRES_USER=campost
+POSTGRES_PASSWORD=campost1234

--- a/.env.local.example
+++ b/.env.local.example
@@ -1,13 +1,5 @@
 # ============================================================
-# CamPost 로컬 backend 실행용 환경변수 템플릿
-# compose(.env)와 분리해서 사용하세요.
-# cp .env.local.example .env.local
+# [DEPRECATED] 이 파일은 더 이상 사용하지 않습니다.
+# .env.example을 복사해 .env 로 사용하세요.
+# cp .env.example .env
 # ============================================================
-
-# ── Spring Boot 필수 값 (RequiredEnvPostProcessor 대상) ──
-SPRING_DATASOURCE_URL=jdbc:postgresql://localhost:5432/campost
-SPRING_DATASOURCE_USERNAME=campost
-SPRING_DATASOURCE_PASSWORD=<REQUIRED>
-APP_CORS_ALLOWED_ORIGINS=http://localhost:5173,http://localhost:3000
-JWT_SECRET=<REQUIRED>
-JWT_EXPIRY_MS=3600000

--- a/README.md
+++ b/README.md
@@ -112,6 +112,19 @@ git commit -m "refactor: 아이콘 리팩토링 (#13)"
 
 ## 6. 백엔드 개발 실행 가이드 (스크립트 기준)
 
+### 6-0. 로컬 개발 DB 설정 (최초 1회)
+
+기본 개발 DB는 **Neon PostgreSQL**을 사용합니다. Docker PostgreSQL은 마이그레이션/초기화 테스트 등 예외적인 경우에만 사용합니다.
+
+1. `.env.example`을 복사해 `.env` 생성: `cp .env.example .env`
+2. `.env`의 `SPRING_DATASOURCE_URL`, `SPRING_DATASOURCE_USERNAME`, `SPRING_DATASOURCE_PASSWORD`를 Neon 연결 정보로 채웁니다.
+   - Neon Dashboard > Connection Details > **Pooled connection string** 사용
+   - Direct connection string은 사용하지 않습니다.
+3. `JWT_SECRET`을 32자 이상의 랜덤 문자열로 채웁니다.
+4. `.env`는 절대 Git에 커밋하지 않습니다.
+
+> Neon 접속 정보는 팀 내부 채널로 공유됩니다.
+
 ### 6-1. 코드를 수정할 때마다 backend 컨테이너를 중지해야 하나요?
 
 아닙니다. 평소 개발에서는 backend를 컨테이너로 띄우지 않고 로컬에서 실행하는 방식이 가장 효율적입니다.
@@ -119,7 +132,7 @@ git commit -m "refactor: 아이콘 리팩토링 (#13)"
 - 평소 개발 권장 방식:
   - docker compose up -d --build 를 매번 사용하지 않음
   - scripts/local-dev.sh 실행
-  - 이 스크립트는 DB만 도커로 띄우고 backend는 로컬 터미널에서 실행
+  - Neon DB 사용 시 Docker DB 기동을 자동으로 스킵하고 바로 Spring Boot 실행
 - 코드 수정 후 반영 방법:
   - local-dev.sh 실행 터미널에서 Ctrl + C
   - 다시 scripts/local-dev.sh 실행
@@ -188,7 +201,7 @@ CamPost-backend/
 │        │  └─ V4__seed_initial_data.sql
 │        └─ application.yml
 ├─ .env.example
-├─ .env.local.example
+├─ .env.local.example       # deprecated
 ├─ docker-compose.yml
 ├─ Dockerfile
 ├─ pom.xml
@@ -199,8 +212,10 @@ CamPost-backend/
 ## 8. 빠른 실행 명령어
 
 ```bash
-# 로컬 개발 (권장)
+# 최초 1회: .env 생성 및 설정 안내
 bash scripts/setup-local.sh
+
+# 로컬 개발 (Neon DB 사용 시 Docker 없이 바로 실행)
 bash scripts/local-dev.sh
 
 # 로컬 검증
@@ -213,7 +228,7 @@ bash scripts/compose-smoke.sh
 ## 9. 백엔드 API/문서 확인
 
 - Health: http://localhost:8080/api/v1/health
-- Swagger UI: http://localhost:8080/swagger-ui.html
+- Swagger UI: http://localhost:8080/swagger-ui/index.html
 - OpenAPI JSON: http://localhost:8080/v3/api-docs
 
 ## 10. 협업 원칙 요약

--- a/scripts/local-dev.sh
+++ b/scripts/local-dev.sh
@@ -4,83 +4,49 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO_ROOT"
 
-ensure_compose_env_file() {
-  if [[ -f .env ]]; then
-    return
-  fi
-
+# ── .env 파일 확인 ──────────────────────────────────────────────
+if [[ ! -f .env ]]; then
   if [[ ! -f .env.example ]]; then
     echo "[ERROR] .env not found and .env.example is missing."
     echo "[ERROR] Create .env manually before running this script."
     exit 1
   fi
-
   cp .env.example .env
   echo "[INFO] Created .env from .env.example"
-}
-
-get_env_value() {
-  local key="$1"
-  grep -E "^${key}=" .env | head -n1 | cut -d '=' -f2- || true
-}
-
-validate_env_keys() {
-  local missing=()
-  local key value
-
-  for key in "$@"; do
-    value="$(get_env_value "$key")"
-    if [[ -z "$value" || "$value" == "<REQUIRED>" ]]; then
-      missing+=("$key")
-    fi
-  done
-
-  if (( ${#missing[@]} > 0 )); then
-    echo "[ERROR] .env is missing required values for db startup: ${missing[*]}"
-    echo "[ERROR] Fill .env first (copied from .env.example if needed), then rerun."
-    exit 1
-  fi
-}
-
-if [[ ! -f .env.local ]]; then
-  if [[ ! -f .env.local.example ]]; then
-    echo "[ERROR] .env.local not found and .env.local.example is missing."
-    exit 1
-  fi
-
-  cp .env.local.example .env.local
-  echo "[INFO] Created .env.local from .env.local.example"
 fi
 
-if grep -q "<REQUIRED>" .env.local; then
-  echo "[ERROR] .env.local contains <REQUIRED> placeholders."
+if grep -q "<REQUIRED>" .env; then
+  echo "[ERROR] .env contains <REQUIRED> placeholders."
   echo "        Fill required values before running backend locally."
   exit 1
 fi
 
-ensure_compose_env_file
-validate_env_keys POSTGRES_DB POSTGRES_USER POSTGRES_PASSWORD
-
-echo "[INFO] Starting PostgreSQL (db) and Mailpit..."
-docker compose up -d db mailpit
-
-echo "[INFO] Waiting for db health check..."
-for _ in $(seq 1 60); do
-  if docker compose ps db | grep -q "healthy"; then
-    break
-  fi
-  sleep 1
-done
-
-if ! docker compose ps db | grep -q "healthy"; then
-  echo "[ERROR] db is not healthy yet. Check logs with: docker compose logs db"
-  exit 1
-fi
-
-echo "[INFO] Loading .env.local and starting backend locally..."
+# ── .env 로드 ──────────────────────────────────────────────────
 set -a
 # shellcheck disable=SC1091
-source .env.local
+source .env
 set +a
 
+# ── DB 기동 (Neon 사용 시 스킵) ────────────────────────────────
+if echo "${SPRING_DATASOURCE_URL:-}" | grep -q "neon.tech"; then
+  echo "[INFO] Neon DB detected — skipping local Docker DB startup."
+else
+  echo "[INFO] Starting local PostgreSQL (db) and Mailpit..."
+  docker compose up -d db mailpit
+
+  echo "[INFO] Waiting for db health check..."
+  for _ in $(seq 1 60); do
+    if docker compose ps db | grep -q "healthy"; then
+      break
+    fi
+    sleep 1
+  done
+
+  if ! docker compose ps db | grep -q "healthy"; then
+    echo "[ERROR] db is not healthy yet. Check logs with: docker compose logs db"
+    exit 1
+  fi
+fi
+
+echo "[INFO] Starting backend locally..."
 exec ./mvnw spring-boot:run

--- a/scripts/local-dev.sh
+++ b/scripts/local-dev.sh
@@ -36,13 +36,13 @@ else
 
   echo "[INFO] Waiting for db health check..."
   for _ in $(seq 1 60); do
-    if docker compose ps db | grep -q "healthy"; then
+    if docker compose ps db | grep -qw "healthy"; then
       break
     fi
     sleep 1
   done
 
-  if ! docker compose ps db | grep -q "healthy"; then
+  if ! docker compose ps db | grep -qw "healthy"; then
     echo "[ERROR] db is not healthy yet. Check logs with: docker compose logs db"
     exit 1
   fi

--- a/scripts/setup-local.sh
+++ b/scripts/setup-local.sh
@@ -4,22 +4,22 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO_ROOT"
 
-if [[ ! -f .env.local ]]; then
-  if [[ ! -f .env.local.example ]]; then
-    echo "[ERROR] .env.local.example not found."
+if [[ ! -f .env ]]; then
+  if [[ ! -f .env.example ]]; then
+    echo "[ERROR] .env.example not found."
     exit 1
   fi
 
-  cp .env.local.example .env.local
-  echo "[INFO] Created .env.local from .env.local.example"
-  echo "[INFO] Fill required values in .env.local before running backend."
+  cp .env.example .env
+  echo "[INFO] Created .env from .env.example"
+  echo "[INFO] Fill required values in .env before running backend."
 else
-  echo "[INFO] .env.local already exists."
+  echo "[INFO] .env already exists."
 fi
 
-if grep -q "<REQUIRED>" .env.local; then
-  echo "[WARN] .env.local still has <REQUIRED> placeholders."
-  echo "[WARN] Please edit .env.local before local backend run."
+if grep -q "<REQUIRED>" .env; then
+  echo "[WARN] .env still has <REQUIRED> placeholders."
+  echo "[WARN] Please edit .env before local backend run."
 fi
 
 echo "[INFO] Local setup check complete."


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #75

## 🏷️ PR 타입

- [ ] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)
- [x] ⚙️ 프로젝트 초기 설정 (Chore)
- [x] 📝 문서 수정 (Documentation)
- [ ] 🚨 PR 복구 (Revert)

## 📝 작업 내용

- `scripts/local-dev.sh` — `.env.local` 제거, `.env` 단일 source로 통일. Neon URL(`neon.tech`) 감지 시 Docker DB 기동 자동 스킵
- `scripts/setup-local.sh` — `.env.local` 대신 `.env` 기준으로 초기화 처리
- `.env.example` — Neon pooled connection string 형식으로 업데이트, 불필요한 항목 제거
- `.env.local.example` — deprecated 안내로 교체
- `README.md` — Neon 기반 로컬 개발 설정 가이드 추가(6-0), Swagger UI URL 수정, 빠른 실행 명령어 업데이트

## 📸 스크린샷

스크립트 변경으로 UI 없음. 동작 흐름:
- `.env`에 Neon URL 설정 후 `bash scripts/local-dev.sh` 실행 시 `[INFO] Neon DB detected — skipping local Docker DB startup.` 출력 후 Spring Boot 기동

## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다.
- [x] 코드 스타일 가이드를 준수했습니다.
- [x] 셀프 리뷰를 완료했습니다.
- [ ] 테스트를 작성하고 모두 통과했습니다.
- [x] 문서를 업데이트했습니다. (필요한 경우)

## 📎 기타 참고사항

- `.env.local`, `.env.local.example`은 deprecated 처리. 기존에 `.env.local`을 사용 중인 팀원은 `.env`로 이전 필요
- Docker PostgreSQL은 완전 제거하지 않고, Neon URL이 아닌 경우 기존 방식대로 Docker DB 기동 (하위 호환 유지)
- 공용 Neon DB에서 임의 삭제/초기화/대량 import 전에 팀에 사전 공유 필요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * 백엔드 로컬 개발 설정 가이드를 확장하고 명확히 했습니다.
  * API 문서 접근 경로를 업데이트했습니다.

* **Chores**
  * 개발 환경 설정 구조를 간소화하고 통합했습니다.
  * 로컬 개발 환경 초기화 프로세스를 단순화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->