### PR TITLE
Feat(#77): Cloudflare R2 URL 필드 추가 (첨부파일)

### DIFF
--- a/src/main/java/com/campost/backend/domain/collect/importer/model/RawNoticePayload.java
+++ b/src/main/java/com/campost/backend/domain/collect/importer/model/RawNoticePayload.java
@@ -56,7 +56,9 @@ public record RawNoticePayload(
             @JsonProperty("preview_pdf_checksum") String previewPdfChecksum,
             @JsonProperty("conversion_status") String conversionStatus,
             @JsonProperty("conversion_engine") String conversionEngine,
-            @JsonProperty("conversion_error") String conversionError
+            @JsonProperty("conversion_error") String conversionError,
+            @JsonProperty("r2_url") String r2Url,
+            @JsonProperty("preview_pdf_r2_url") String previewPdfR2Url
     ) {
     }
 }

--- a/src/main/java/com/campost/backend/domain/collect/importer/repository/RawImporterRepository.java
+++ b/src/main/java/com/campost/backend/domain/collect/importer/repository/RawImporterRepository.java
@@ -206,13 +206,15 @@ public class RawImporterRepository {
                     file_size, checksum, source_url, local_path, download_ok,
                     extracted_text, extracted_chars, parser, parse_quality, parse_ok, download_cached,
                     preview_pdf_path, preview_pdf_size, preview_pdf_checksum,
-                    conversion_status, conversion_engine, conversion_error
+                    conversion_status, conversion_engine, conversion_error,
+                    r2_url, preview_pdf_r2_url
                 ) VALUES (
                     :noticeId, :fileKey, :originalName, :ext, :fileType, :mimeType,
                     :fileSize, :checksum, :sourceUrl, :localPath, :downloadOk,
                     :extractedText, :extractedChars, :parser, :parseQuality, :parseOk, :downloadCached,
                     :previewPdfPath, :previewPdfSize, :previewPdfChecksum,
-                    :conversionStatus, :conversionEngine, :conversionError
+                    :conversionStatus, :conversionEngine, :conversionError,
+                    :r2Url, :previewPdfR2Url
                 )
                 ON CONFLICT (file_key) DO UPDATE SET
                     notice_id = EXCLUDED.notice_id,
@@ -236,7 +238,9 @@ public class RawImporterRepository {
                     preview_pdf_checksum = EXCLUDED.preview_pdf_checksum,
                     conversion_status = EXCLUDED.conversion_status,
                     conversion_engine = EXCLUDED.conversion_engine,
-                    conversion_error = EXCLUDED.conversion_error
+                    conversion_error = EXCLUDED.conversion_error,
+                    r2_url = EXCLUDED.r2_url,
+                    preview_pdf_r2_url = EXCLUDED.preview_pdf_r2_url
                 """;
 
         String fileKey = requireMaxLength(requiredValue(attachment.fileKey(), "file_key"), "file_key", 500);
@@ -286,6 +290,8 @@ public class RawImporterRepository {
                 .param("conversionStatus", normalizeConversionStatus(attachment.conversionStatus()))
                 .param("conversionEngine", conversionEngine)
                 .param("conversionError", attachment.conversionError())
+                .param("r2Url", requireMaxLength(trimToNull(attachment.r2Url()), "r2_url", 500))
+                .param("previewPdfR2Url", requireMaxLength(trimToNull(attachment.previewPdfR2Url()), "preview_pdf_r2_url", 500))
                 .update();
     }
 

--- a/src/main/java/com/campost/backend/domain/collect/importer/repository/RawImporterRepository.java
+++ b/src/main/java/com/campost/backend/domain/collect/importer/repository/RawImporterRepository.java
@@ -290,8 +290,8 @@ public class RawImporterRepository {
                 .param("conversionStatus", normalizeConversionStatus(attachment.conversionStatus()))
                 .param("conversionEngine", conversionEngine)
                 .param("conversionError", attachment.conversionError())
-                .param("r2Url", requireMaxLength(trimToNull(attachment.r2Url()), "r2_url", 500))
-                .param("previewPdfR2Url", requireMaxLength(trimToNull(attachment.previewPdfR2Url()), "preview_pdf_r2_url", 500))
+                .param("r2Url", requireMaxLength(trimToNull(attachment.r2Url()), "r2_url", 2048))
+                .param("previewPdfR2Url", requireMaxLength(trimToNull(attachment.previewPdfR2Url()), "preview_pdf_r2_url", 2048))
                 .update();
     }
 

--- a/src/main/java/com/campost/backend/domain/post/notice/dto/NoticeDetailDto.java
+++ b/src/main/java/com/campost/backend/domain/post/notice/dto/NoticeDetailDto.java
@@ -93,6 +93,7 @@ public record NoticeDetailDto(
             "checksum",
             "sourceUrl",
             "localPath",
+            "r2Url",
             "downloadOk",
             "extractedText",
             "extractedChars",
@@ -101,6 +102,7 @@ public record NoticeDetailDto(
             "parseOk",
             "downloadCached",
             "previewPdfPath",
+            "previewPdfR2Url",
             "previewPdfSize",
             "previewPdfChecksum",
             "conversionStatus",
@@ -129,6 +131,8 @@ public record NoticeDetailDto(
             String sourceUrl,
             @JsonProperty("localPath")
             String localPath,
+            @JsonProperty("r2Url")
+            String r2Url,
             @JsonProperty("downloadOk")
             Boolean downloadOk,
             @JsonProperty("extractedText")
@@ -145,6 +149,8 @@ public record NoticeDetailDto(
             Boolean downloadCached,
             @JsonProperty("previewPdfPath")
             String previewPdfPath,
+            @JsonProperty("previewPdfR2Url")
+            String previewPdfR2Url,
             @JsonProperty("previewPdfSize")
             Long previewPdfSize,
             @JsonProperty("previewPdfChecksum")

--- a/src/main/java/com/campost/backend/domain/post/notice/repository/NoticeQueryRepository.java
+++ b/src/main/java/com/campost/backend/domain/post/notice/repository/NoticeQueryRepository.java
@@ -145,9 +145,9 @@ public class NoticeQueryRepository {
     private List<AttachmentDto> findAttachmentsByNoticeId(long noticeId) {
         String sql = """
                 SELECT id, file_key, original_name, ext, file_type, mime_type, file_size,
-                       checksum, source_url, local_path, download_ok, extracted_text,
+                       checksum, source_url, local_path, r2_url, download_ok, extracted_text,
                        extracted_chars, parser, parse_quality, parse_ok, download_cached,
-                       preview_pdf_path, preview_pdf_size, preview_pdf_checksum,
+                       preview_pdf_path, preview_pdf_r2_url, preview_pdf_size, preview_pdf_checksum,
                        conversion_status, conversion_engine, conversion_error, created_at
                 FROM notice_attachments
                 WHERE notice_id = :noticeId
@@ -167,6 +167,7 @@ public class NoticeQueryRepository {
                         rs.getString("checksum"),
                         rs.getString("source_url"),
                         rs.getString("local_path"),
+                        rs.getString("r2_url"),
                         rs.getObject("download_ok", Boolean.class),
                         rs.getString("extracted_text"),
                         rs.getObject("extracted_chars", Integer.class),
@@ -175,6 +176,7 @@ public class NoticeQueryRepository {
                         rs.getObject("parse_ok", Boolean.class),
                         rs.getObject("download_cached", Boolean.class),
                         rs.getString("preview_pdf_path"),
+                        rs.getString("preview_pdf_r2_url"),
                         rs.getObject("preview_pdf_size", Long.class),
                         rs.getString("preview_pdf_checksum"),
                         rs.getString("conversion_status"),

--- a/src/main/resources/db/migration/V15__add_r2_url_to_attachments.sql
+++ b/src/main/resources/db/migration/V15__add_r2_url_to_attachments.sql
@@ -3,5 +3,5 @@
 -- ============================================================
 
 ALTER TABLE notice_attachments
-    ADD COLUMN IF NOT EXISTS r2_url VARCHAR(500),
-    ADD COLUMN IF NOT EXISTS preview_pdf_r2_url VARCHAR(500);
+    ADD COLUMN IF NOT EXISTS r2_url VARCHAR(2048),
+    ADD COLUMN IF NOT EXISTS preview_pdf_r2_url VARCHAR(2048);

--- a/src/main/resources/db/migration/V15__add_r2_url_to_attachments.sql
+++ b/src/main/resources/db/migration/V15__add_r2_url_to_attachments.sql
@@ -1,0 +1,7 @@
+-- ============================================================
+-- CamPost Notice Attachments - Cloudflare R2 URL fields
+-- ============================================================
+
+ALTER TABLE notice_attachments
+    ADD COLUMN IF NOT EXISTS r2_url VARCHAR(500),
+    ADD COLUMN IF NOT EXISTS preview_pdf_r2_url VARCHAR(500);


### PR DESCRIPTION
## 개요
파이프라인이 R2에 업로드한 파일 URL을 DB에 저장하고 API 응답에 포함한다.

## 변경 파일
- `V15__add_r2_url_to_attachments.sql` — `notice_attachments`에 `r2_url`, `preview_pdf_r2_url` 컬럼 추가
- `RawNoticePayload.java` — `RawAttachmentPayload`에 `r2Url`, `previewPdfR2Url` 필드 추가
- `RawImporterRepository.java` — `upsertAttachment` INSERT/UPDATE에 신규 컬럼 처리
- `NoticeDetailDto.java` — `AttachmentDto`에 `r2Url`, `previewPdfR2Url` 필드 추가
- `NoticeQueryRepository.java` — SELECT 쿼리 및 row mapper 업데이트

## 동작 방식
- 파이프라인이 R2 업로드 후 `r2_url`, `preview_pdf_r2_url`을 raw JSON에 포함
- Importer가 JSON을 읽어 DB에 저장
- 프론트엔드는 API 응답의 `r2Url` / `previewPdfR2Url`로 파일에 직접 접근

## 테스트 결과
- 파이프라인 R2 연동 후 재크롤링 → Importer 실행 → API 응답에 r2Url 포함 확인 필요

Closes #77