### PR TITLE
Feat(#84): Resend API 이메일 인증 발송 추가

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,9 +16,18 @@ JWT_SECRET=<REQUIRED>
 JWT_EXPIRY_MS=3600000
 
 # ── 메일 인증 ────────────────────────────────────────────────
-# 로컬: logging (실제 메일 발송 없이 콘솔 출력)
-# 운영: smtp (별도 SMTP 설정 필요)
+# logging : 실제 발송 없이 콘솔 출력 (로컬 기본)
+# resend  : Resend HTTP API로 발송 (배포 권장 — Render Free는 SMTP 포트 차단됨)
+# smtp    : JavaMail SMTP로 발송 (Render 유료 인스턴스 등 SMTP 허용 환경에서만)
 APP_MAIL_VERIFICATION_SENDER=logging
+
+# 발신 주소
+#  - resend 모드: Resend에서 검증한 도메인 주소, 또는 테스트용 onboarding@resend.dev
+#  - smtp 모드  : 발송 계정 주소
+APP_MAIL_FROM=onboarding@resend.dev
+
+# Resend API Key (resend 모드에서만 필요) — https://resend.com/api-keys
+RESEND_API_KEY=
 
 # ── Importer (Raw JSON → DB) ─────────────────────────────────
 # 로컬에서 importer 실행 시 true로 변경, Render 배포는 false 유지

--- a/src/main/java/com/campost/backend/domain/auth/service/ResendEmailVerificationSender.java
+++ b/src/main/java/com/campost/backend/domain/auth/service/ResendEmailVerificationSender.java
@@ -1,0 +1,99 @@
+package com.campost.backend.domain.auth.service;
+
+import com.campost.backend.domain.auth.exception.EmailVerificationSendException;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+/**
+ * Sends email verification codes through the Resend HTTP API.
+ *
+ * <p>Render Free 웹 서비스는 SMTP 포트(25/465/587) outbound를 차단하므로, SMTP 대신
+ * HTTPS(443) 기반 Resend API로 메일을 발송한다. 발신 주소(app.mail.from)는 Resend에서
+ * 검증한 도메인 주소이거나, 테스트용 onboarding@resend.dev 여야 한다.
+ */
+@Component
+@ConditionalOnProperty(
+        name = "app.mail.verification-sender",
+        havingValue = "resend"
+)
+public class ResendEmailVerificationSender implements EmailVerificationSender {
+
+    private static final Logger log = LoggerFactory.getLogger(ResendEmailVerificationSender.class);
+    private static final String RESEND_API_URL = "https://api.resend.com/emails";
+    private static final int CONNECT_TIMEOUT_MS = 5_000;
+    private static final int READ_TIMEOUT_MS = 8_000;
+
+    private final RestClient restClient;
+    private final String from;
+
+    public ResendEmailVerificationSender(
+            @Value("${app.mail.resend.api-key}") String apiKey,
+            @Value("${app.mail.from}") String from
+    ) {
+        this.from = from;
+
+        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+        requestFactory.setConnectTimeout(CONNECT_TIMEOUT_MS);
+        requestFactory.setReadTimeout(READ_TIMEOUT_MS);
+
+        this.restClient = RestClient.builder()
+                .baseUrl(RESEND_API_URL)
+                .requestFactory(requestFactory)
+                .defaultHeader("Authorization", "Bearer " + apiKey)
+                .build();
+    }
+
+    @Override
+    public void send(String email, String code) {
+        Map<String, Object> payload = Map.of(
+                "from", from,
+                "to", List.of(email),
+                "subject", "CamPost 이메일 인증번호",
+                "text", buildText(code)
+        );
+
+        try {
+            restClient.post()
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(payload)
+                    .retrieve()
+                    .toBodilessEntity();
+        } catch (RestClientException exception) {
+            log.warn(
+                    "Failed to send email verification code via Resend. email={}, reason={}",
+                    maskEmail(email),
+                    exception.getMessage()
+            );
+            throw new EmailVerificationSendException(exception);
+        }
+    }
+
+    private String buildText(String code) {
+        return """
+                CamPost 회원가입 이메일 인증번호입니다.
+
+                인증번호: %s
+
+                인증번호는 %d분 동안 유효합니다.
+                본인이 요청하지 않았다면 이 메일을 무시해주세요.
+                """.formatted(code, EmailVerificationPolicy.CODE_TTL_MINUTES);
+    }
+
+    private String maskEmail(String email) {
+        int atIndex = email.indexOf('@');
+        if (atIndex <= 1) {
+            return "***" + email.substring(Math.max(atIndex, 0));
+        }
+
+        return email.charAt(0) + "***" + email.substring(atIndex);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -38,6 +38,8 @@ app:
   mail:
     verification-sender: ${APP_MAIL_VERIFICATION_SENDER:logging}
     from: ${APP_MAIL_FROM:no-reply@campost.local}
+    resend:
+      api-key: ${RESEND_API_KEY:}
   files:
     dir: ${FILES_DIR:/data/files}
   importer:


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #84

## 🏷️ PR 타입

- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)
- [ ] ⚙️ 프로젝트 초기 설정 (Chore)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🚨 PR 복구 (Revert)

## 📝 작업 내용

- `ResendEmailVerificationSender` 추가 — Resend HTTP API로 인증 메일 발송 (`app.mail.verification-sender=resend`일 때 활성화)
- RestClient 기반 구현, connect 5s / read 8s 타임아웃 설정 (프론트 10s 타임아웃 대비)
- `application.yml`에 `app.mail.resend.api-key` 설정 추가
- `.env.example`에 resend 모드 및 환경변수 안내 추가
- 기존 `logging`/`smtp` 구현은 그대로 유지

## 📎 기타 참고사항

- **배경**: Render Free 웹 서비스는 SMTP 포트(25/465/587) outbound를 차단하여 Gmail SMTP 발송이 불가능. HTTPS(443) 기반 Resend API로 전환.
- **배포 환경변수**: `APP_MAIL_VERIFICATION_SENDER=resend`, `APP_MAIL_FROM=noreply@campost.xyz`, `RESEND_API_KEY`
- `campost.xyz` 도메인 Resend 검증 완료

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * Resend 이메일 서비스를 통한 이메일 인증 제공자 지원 추가

* **설정**
  * 새로운 환경변수 추가: `APP_MAIL_FROM` (이메일 발신 주소), `RESEND_API_KEY` (Resend API 키)
  * 애플리케이션 설정에 Resend API 구성 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->