### PR TITLE
Feat(#88): 북마크 목록 조회 및 공지 북마크 여부 API

### DIFF
--- a/src/main/java/com/campost/backend/domain/post/notice/controller/NoticeQueryController.java
+++ b/src/main/java/com/campost/backend/domain/post/notice/controller/NoticeQueryController.java
@@ -1,11 +1,13 @@
 package com.campost.backend.domain.post.notice.controller;
 
 import com.campost.backend.global.api.ApiResponse;
+import com.campost.backend.global.auth.LoginUser;
 import com.campost.backend.domain.post.notice.dto.NoticeDetailDto;
 import com.campost.backend.domain.post.notice.dto.NoticeDto;
 import com.campost.backend.domain.post.notice.service.NoticeQueryService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -31,27 +33,52 @@ public class NoticeQueryController {
         this.noticeQueryService = noticeQueryService;
     }
 
-    @Operation(summary = "공지 목록 조회", description = "최신 및 마감 임박 공지 목록을 학과별로 조회합니다.")
+    @Operation(summary = "공지 목록 조회", description = "최신 및 마감 임박 공지 목록을 학과별로 조회합니다. 로그인 상태면 isBookmarked가 채워집니다.")
     @GetMapping
     public ApiResponse<List<NoticeDto>> getNotices(
             @Parameter(description = "조회 개수 (1~100)")
             @RequestParam(defaultValue = "20") @Min(1) @Max(100) int limit,
-            
+
             @Parameter(description = "학과 코드 필터링 (예: cse)", required = false)
             @RequestParam(required = false) String deptCode,
-            
+
             @Parameter(description = "정렬 방식 (recent: 최신순, deadline: 마감임박순)", required = false)
-            @RequestParam(defaultValue = "recent") String sortBy
+            @RequestParam(defaultValue = "recent") String sortBy,
+
+            @Parameter(hidden = true)
+            @LoginUser(required = false) Long userId
     ) {
-        return ApiResponse.ok(noticeQueryService.getNotices(limit, deptCode, sortBy));
+        return ApiResponse.ok(noticeQueryService.getNotices(limit, deptCode, sortBy, userId));
     }
 
-    @Operation(summary = "공지 상세 조회", description = "공지 1건의 상세 정보를 조회합니다.")
+    @Operation(
+            summary = "내 북마크 공지 목록 조회",
+            description = "로그인한 사용자가 북마크한 공지 목록을 최근 북마크순으로 조회합니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @GetMapping("/bookmarked")
+    public ApiResponse<List<NoticeDto>> getBookmarkedNotices(
+            @Parameter(hidden = true)
+            @LoginUser long userId,
+
+            @Parameter(description = "조회 개수 (1~100)")
+            @RequestParam(defaultValue = "50") @Min(1) @Max(100) int limit
+    ) {
+        return ApiResponse.ok(noticeQueryService.getBookmarkedNotices(userId, limit));
+    }
+
+    @Operation(
+            summary = "공지 상세 조회",
+            description = "공지 1건의 상세 정보를 조회합니다. 로그인 상태면 isBookmarked가 채워집니다."
+    )
     @GetMapping("/{noticeId}")
     public ApiResponse<NoticeDetailDto> getNoticeDetail(
             @Parameter(description = "공지 ID")
-            @PathVariable @Positive long noticeId
+            @PathVariable @Positive long noticeId,
+
+            @Parameter(hidden = true)
+            @LoginUser(required = false) Long userId
     ) {
-        return ApiResponse.ok(noticeQueryService.getNoticeDetail(noticeId));
+        return ApiResponse.ok(noticeQueryService.getNoticeDetail(noticeId, userId));
     }
 }

--- a/src/main/java/com/campost/backend/domain/post/notice/dto/NoticeDetailDto.java
+++ b/src/main/java/com/campost/backend/domain/post/notice/dto/NoticeDetailDto.java
@@ -33,7 +33,8 @@ import java.util.List;
         "attachments",
         "sourceUrl",
         "publishedAt",
-        "createdAt"
+        "createdAt",
+        "isBookmarked"
 })
 public record NoticeDetailDto(
         @JsonProperty("id")
@@ -79,7 +80,9 @@ public record NoticeDetailDto(
         @JsonProperty("publishedAt")
         OffsetDateTime publishedAt,
         @JsonProperty("createdAt")
-        OffsetDateTime createdAt
+        OffsetDateTime createdAt,
+        @JsonProperty("isBookmarked")
+        boolean isBookmarked
 ) {
     @JsonInclude(JsonInclude.Include.ALWAYS)
     @JsonPropertyOrder({

--- a/src/main/java/com/campost/backend/domain/post/notice/dto/NoticeDto.java
+++ b/src/main/java/com/campost/backend/domain/post/notice/dto/NoticeDto.java
@@ -23,7 +23,8 @@ import java.time.OffsetDateTime;
         "target",
         "applyMethod",
         "publishedAt",
-        "createdAt"
+        "createdAt",
+        "isBookmarked"
 })
 public record NoticeDto(
         @JsonProperty("id")
@@ -55,6 +56,8 @@ public record NoticeDto(
         @JsonProperty("publishedAt")
         OffsetDateTime publishedAt,
         @JsonProperty("createdAt")
-        OffsetDateTime createdAt
+        OffsetDateTime createdAt,
+        @JsonProperty("isBookmarked")
+        boolean isBookmarked
 ) {
 }

--- a/src/main/java/com/campost/backend/domain/post/notice/repository/NoticeQueryRepository.java
+++ b/src/main/java/com/campost/backend/domain/post/notice/repository/NoticeQueryRepository.java
@@ -23,10 +23,93 @@ public class NoticeQueryRepository {
         this.objectMapper = objectMapper;
     }
 
-    public List<NoticeDto> findNotices(int limit, String deptCode, String sortBy) {
+    public List<NoticeDto> findNotices(int limit, String deptCode, String sortBy, Long userId) {
         boolean hasDeptCode = deptCode != null && !deptCode.isBlank();
 
         StringBuilder sql = new StringBuilder("""
+                SELECT n.id, n.article_id, n.title, cs.department, n.author, n.category, n.date, n.views,
+                       n.source_url,
+                       (
+                         SELECT image_asset ->> 'src'
+                         FROM jsonb_array_elements(COALESCE(n.content_assets -> 'images', '[]'::jsonb))
+                              WITH ORDINALITY AS images(image_asset, ordinal)
+                         WHERE COALESCE((image_asset ->> 'file_size')::bigint, 0) >= 10000
+                           AND COALESCE(image_asset ->> 'original_src', '') NOT ILIKE '%fonts.gstatic.com%'
+                           AND NOT (
+                             COALESCE(image_asset ->> 'original_src', '') LIKE 'data:image%'
+                             AND COALESCE((image_asset ->> 'file_size')::bigint, 0) < 100000
+                           )
+                         ORDER BY
+                             CASE
+                               WHEN COALESCE(image_asset ->> 'name', '') ILIKE '%포스터%'
+                                 OR COALESCE(image_asset ->> 'name', '') ILIKE '%poster%'
+                               THEN 0
+                               ELSE 1
+                             END,
+                           CASE WHEN image_asset ->> 'role' = 'body' THEN 0 ELSE 1 END,
+                           ordinal
+                         LIMIT 1
+                       ) AS thumbnail_path,
+                       n.deadline, n.target, n.apply_method, n.published_at, n.created_at,
+                       CASE
+                         WHEN :userId IS NULL THEN FALSE
+                         ELSE EXISTS (
+                           SELECT 1 FROM bookmarks b
+                           WHERE b.notice_id = n.id AND b.user_id = :userId
+                         )
+                       END AS is_bookmarked
+                FROM notices n
+                LEFT JOIN raw_notices rn ON n.raw_notice_id = rn.id
+                LEFT JOIN crawl_sources cs ON rn.source_id = cs.id
+                WHERE 1=1
+                """);
+
+        if (hasDeptCode) {
+            sql.append(" AND cs.dept_code = :deptCode ");
+        }
+
+        if ("deadline".equalsIgnoreCase(sortBy)) {
+            // 마감 임박순 (이미 마감된 공지 제외)
+            sql.append(" AND n.deadline IS NOT NULL AND n.deadline >= CURRENT_DATE ");
+            sql.append(" ORDER BY n.deadline ASC NULLS LAST, n.id DESC ");
+        } else {
+            // 최신순 (기본값)
+            sql.append(" ORDER BY COALESCE(n.published_at, n.crawled_at, n.created_at) DESC NULLS LAST, n.id DESC ");
+        }
+
+        sql.append(" LIMIT :limit");
+
+        var query = jdbcClient.sql(sql.toString())
+                .param("limit", limit)
+                .param("userId", userId);
+
+        if (hasDeptCode) {
+            query = query.param("deptCode", deptCode);
+        }
+
+        return query.query((rs, rowNum) -> new NoticeDto(
+                        rs.getLong("id"),
+                        rs.getString("article_id"),
+                        rs.getString("title"),
+                        rs.getString("department"),
+                        rs.getString("author"),
+                        rs.getString("category"),
+                        rs.getObject("date", java.time.LocalDate.class),
+                        rs.getObject("views", Integer.class),
+                        rs.getString("source_url"),
+                        rs.getString("thumbnail_path"),
+                        rs.getObject("deadline", java.time.LocalDate.class),
+                        rs.getString("target"),
+                        rs.getString("apply_method"),
+                        rs.getObject("published_at", java.time.OffsetDateTime.class),
+                        rs.getObject("created_at", java.time.OffsetDateTime.class),
+                        rs.getBoolean("is_bookmarked")
+                ))
+                .list();
+    }
+
+    public List<NoticeDto> findBookmarkedNotices(long userId, int limit) {
+        String sql = """
                 SELECT n.id, n.article_id, n.title, cs.department, n.author, n.category, n.date, n.views,
                        n.source_url,
                        (
@@ -54,32 +137,16 @@ public class NoticeQueryRepository {
                 FROM notices n
                 LEFT JOIN raw_notices rn ON n.raw_notice_id = rn.id
                 LEFT JOIN crawl_sources cs ON rn.source_id = cs.id
-                WHERE 1=1
-                """);
+                JOIN bookmarks b ON b.notice_id = n.id
+                WHERE b.user_id = :userId
+                ORDER BY b.created_at DESC NULLS LAST, n.id DESC
+                LIMIT :limit
+                """;
 
-        if (hasDeptCode) {
-            sql.append(" AND cs.dept_code = :deptCode ");
-        }
-
-        if ("deadline".equalsIgnoreCase(sortBy)) {
-            // 마감 임박순 (이미 마감된 공지 제외)
-            sql.append(" AND n.deadline IS NOT NULL AND n.deadline >= CURRENT_DATE ");
-            sql.append(" ORDER BY n.deadline ASC NULLS LAST, n.id DESC ");
-        } else {
-            // 최신순 (기본값)
-            sql.append(" ORDER BY COALESCE(n.published_at, n.crawled_at, n.created_at) DESC NULLS LAST, n.id DESC ");
-        }
-
-        sql.append(" LIMIT :limit");
-
-        var query = jdbcClient.sql(sql.toString())
-                .param("limit", limit);
-
-        if (hasDeptCode) {
-            query = query.param("deptCode", deptCode);
-        }
-
-        return query.query((rs, rowNum) -> new NoticeDto(
+        return jdbcClient.sql(sql)
+                .param("userId", userId)
+                .param("limit", limit)
+                .query((rs, rowNum) -> new NoticeDto(
                         rs.getLong("id"),
                         rs.getString("article_id"),
                         rs.getString("title"),
@@ -94,19 +161,27 @@ public class NoticeQueryRepository {
                         rs.getString("target"),
                         rs.getString("apply_method"),
                         rs.getObject("published_at", java.time.OffsetDateTime.class),
-                        rs.getObject("created_at", java.time.OffsetDateTime.class)
+                        rs.getObject("created_at", java.time.OffsetDateTime.class),
+                        true
                 ))
                 .list();
     }
 
-    public Optional<NoticeDetailDto> findNoticeDetailById(long noticeId) {
+    public Optional<NoticeDetailDto> findNoticeDetailById(long noticeId, Long userId) {
         String sql = """
                 SELECT n.id, n.article_id, n.title, cs.department, n.author, n.category, n.date, n.views,
                        n.deadline, n.deadline_time, n.deadline_at,
                        n.target, n.apply_method, n.body_text, n.body_html,
                        n.content_html, n.content_assets::text AS content_assets,
                        n.content_stats::text AS content_stats,
-                       n.source_url, n.published_at, n.created_at
+                       n.source_url, n.published_at, n.created_at,
+                       CASE
+                         WHEN :userId IS NULL THEN FALSE
+                         ELSE EXISTS (
+                           SELECT 1 FROM bookmarks b
+                           WHERE b.notice_id = n.id AND b.user_id = :userId
+                         )
+                       END AS is_bookmarked
                 FROM notices n
               LEFT JOIN raw_notices rn ON n.raw_notice_id = rn.id
               LEFT JOIN crawl_sources cs ON rn.source_id = cs.id
@@ -115,6 +190,7 @@ public class NoticeQueryRepository {
 
         return jdbcClient.sql(sql)
                 .param("noticeId", noticeId)
+                .param("userId", userId)
                 .query((rs, rowNum) -> new NoticeDetailDto(
                         rs.getLong("id"),
                         rs.getString("article_id"),
@@ -137,7 +213,8 @@ public class NoticeQueryRepository {
                         findAttachmentsByNoticeId(noticeId),
                         rs.getString("source_url"),
                         rs.getObject("published_at", java.time.OffsetDateTime.class),
-                        rs.getObject("created_at", java.time.OffsetDateTime.class)
+                        rs.getObject("created_at", java.time.OffsetDateTime.class),
+                        rs.getBoolean("is_bookmarked")
                 ))
                 .optional();
     }

--- a/src/main/java/com/campost/backend/domain/post/notice/repository/NoticeQueryRepository.java
+++ b/src/main/java/com/campost/backend/domain/post/notice/repository/NoticeQueryRepository.java
@@ -52,10 +52,10 @@ public class NoticeQueryRepository {
                        ) AS thumbnail_path,
                        n.deadline, n.target, n.apply_method, n.published_at, n.created_at,
                        CASE
-                         WHEN :userId IS NULL THEN FALSE
+                         WHEN CAST(:userId AS bigint) IS NULL THEN FALSE
                          ELSE EXISTS (
                            SELECT 1 FROM bookmarks b
-                           WHERE b.notice_id = n.id AND b.user_id = :userId
+                           WHERE b.notice_id = n.id AND b.user_id = CAST(:userId AS bigint)
                          )
                        END AS is_bookmarked
                 FROM notices n
@@ -176,10 +176,10 @@ public class NoticeQueryRepository {
                        n.content_stats::text AS content_stats,
                        n.source_url, n.published_at, n.created_at,
                        CASE
-                         WHEN :userId IS NULL THEN FALSE
+                         WHEN CAST(:userId AS bigint) IS NULL THEN FALSE
                          ELSE EXISTS (
                            SELECT 1 FROM bookmarks b
-                           WHERE b.notice_id = n.id AND b.user_id = :userId
+                           WHERE b.notice_id = n.id AND b.user_id = CAST(:userId AS bigint)
                          )
                        END AS is_bookmarked
                 FROM notices n

--- a/src/main/java/com/campost/backend/domain/post/notice/service/NoticeQueryService.java
+++ b/src/main/java/com/campost/backend/domain/post/notice/service/NoticeQueryService.java
@@ -21,13 +21,17 @@ public class NoticeQueryService {
         this.noticeQueryRepository = noticeQueryRepository;
     }
 
-    public List<NoticeDto> getNotices(int limit, String deptCode, String sortBy) {
-        return noticeQueryRepository.findNotices(normalizeLimit(limit), deptCode, sortBy);
+    public List<NoticeDto> getNotices(int limit, String deptCode, String sortBy, Long userId) {
+        return noticeQueryRepository.findNotices(normalizeLimit(limit), deptCode, sortBy, userId);
     }
 
-    public NoticeDetailDto getNoticeDetail(long noticeId) {
-        return noticeQueryRepository.findNoticeDetailById(noticeId)
+    public NoticeDetailDto getNoticeDetail(long noticeId, Long userId) {
+        return noticeQueryRepository.findNoticeDetailById(noticeId, userId)
                 .orElseThrow(() -> new NoSuchElementException("Notice not found: " + noticeId));
+    }
+
+    public List<NoticeDto> getBookmarkedNotices(long userId, int limit) {
+        return noticeQueryRepository.findBookmarkedNotices(userId, normalizeLimit(limit));
     }
 
     private int normalizeLimit(int limit) {

--- a/src/main/java/com/campost/backend/global/auth/LoginUser.java
+++ b/src/main/java/com/campost/backend/global/auth/LoginUser.java
@@ -8,4 +8,11 @@ import java.lang.annotation.Target;
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface LoginUser {
+
+    /**
+     * true면 토큰이 없거나 유효하지 않을 때 예외를 던진다(필수 인증).
+     * false면 비로그인/유효하지 않은 토큰일 때 null을 주입한다(선택적 인증).
+     * required=false로 쓰려면 파라미터 타입이 박싱 타입(Long)이어야 한다.
+     */
+    boolean required() default true;
 }

--- a/src/main/java/com/campost/backend/global/auth/LoginUserArgumentResolver.java
+++ b/src/main/java/com/campost/backend/global/auth/LoginUserArgumentResolver.java
@@ -37,23 +37,36 @@ public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver 
             NativeWebRequest webRequest,
             WebDataBinderFactory binderFactory
     ) {
+        LoginUser annotation = parameter.getParameterAnnotation(LoginUser.class);
+        boolean required = annotation == null || annotation.required();
+
         String authorization = webRequest.getHeader(AUTHORIZATION_HEADER);
 
         if (authorization == null || !authorization.regionMatches(true, 0, BEARER_PREFIX, 0, BEARER_PREFIX.length())) {
+            if (!required) {
+                return null;
+            }
             throw new InvalidTokenException("Missing bearer token.");
         }
 
-        String token = authorization.substring(BEARER_PREFIX.length()).trim();
-        Claims claims = jwtTokenService.parse(token);
-        String subject = claims.getSubject();
-
-        if (subject == null || subject.isBlank()) {
-            throw new InvalidTokenException("Invalid token subject.");
-        }
-
         try {
+            String token = authorization.substring(BEARER_PREFIX.length()).trim();
+            Claims claims = jwtTokenService.parse(token);
+            String subject = claims.getSubject();
+
+            if (subject == null || subject.isBlank()) {
+                throw new InvalidTokenException("Invalid token subject.");
+            }
+
             return Long.parseLong(subject);
-        } catch (NumberFormatException ex) {
+        } catch (RuntimeException ex) {
+            // 선택적 인증: 토큰이 만료/위조 등으로 유효하지 않으면 비로그인으로 간주한다.
+            if (!required) {
+                return null;
+            }
+            if (ex instanceof InvalidTokenException) {
+                throw ex;
+            }
             throw new InvalidTokenException("Invalid token subject.");
         }
     }


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #88

## 🏷️ PR 타입

- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)
- [ ] ⚙️ 프로젝트 초기 설정 (Chore)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🚨 PR 복구 (Revert)

## 📝 작업 내용

- `@LoginUser(required = false)` 선택적 인증 지원 — 공개 엔드포인트에서 로그인 시 userId 주입, 비로그인/유효하지 않은 토큰은 null
- `GET /api/v1/notices/bookmarked` 추가 — 사용자가 북마크한 공지 목록 (최근 북마크순)
- `GET /api/v1/notices`, `GET /api/v1/notices/{id}`에 `isBookmarked` 추가 (로그인 시 EXISTS로 계산)
- `NoticeDto`, `NoticeDetailDto`에 `isBookmarked` 필드 추가

## 📎 기타 참고사항

- 비로그인 요청은 isBookmarked=false, 만료/위조 토큰도 비로그인으로 안전 처리
- 로컬 검증: 테스트 72개 전부 통과(BUILD SUCCESS)
- 프론트엔드 연동 PR과 함께 배포되어야 마이페이지 북마크 기능이 동작

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 공지사항 목록 및 상세 페이지에 사용자별 북마크 상태 표시 기능 추가
  * 사용자가 북마크한 공지사항만 조회할 수 있는 새로운 엔드포인트 추가

* **Improvements**
  * 비로그인 사용자도 공지사항을 조회할 수 있도록 인증 요구사항 유연화
  * 선택적 인증 처리 메커니즘 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->