### PR TITLE
Fix(#90): 로그인 응답 profileCompleted 추가 (온보딩 재노출 버그)

### DIFF
--- a/src/main/java/com/campost/backend/domain/auth/dto/LoginResponse.java
+++ b/src/main/java/com/campost/backend/domain/auth/dto/LoginResponse.java
@@ -9,7 +9,8 @@ public record LoginResponse(
         String refreshToken,
         String tokenType,
         long expiresIn,
-        long refreshTokenExpiresIn
+        long refreshTokenExpiresIn,
+        boolean profileCompleted
 ) {
     public static LoginResponse of(
             long userId,
@@ -19,7 +20,8 @@ public record LoginResponse(
             String accessToken,
             String refreshToken,
             long expiresIn,
-            long refreshTokenExpiresIn
+            long refreshTokenExpiresIn,
+            boolean profileCompleted
     ) {
         return new LoginResponse(
                 userId,
@@ -30,7 +32,8 @@ public record LoginResponse(
                 refreshToken,
                 "Bearer",
                 expiresIn,
-                refreshTokenExpiresIn
+                refreshTokenExpiresIn,
+                profileCompleted
         );
     }
 }

--- a/src/main/java/com/campost/backend/domain/auth/service/LoginService.java
+++ b/src/main/java/com/campost/backend/domain/auth/service/LoginService.java
@@ -5,6 +5,7 @@ import com.campost.backend.domain.auth.dto.LoginResponse;
 import com.campost.backend.domain.auth.exception.BadCredentialsException;
 import com.campost.backend.domain.auth.model.User;
 import com.campost.backend.domain.auth.repository.UserRepository;
+import com.campost.backend.domain.user.model.UserProfile;
 import com.campost.backend.global.jwt.JwtTokenService;
 import org.springframework.stereotype.Service;
 
@@ -48,6 +49,11 @@ public class LoginService {
         );
         String refreshToken = jwtTokenService.generateRefreshToken(user.id());
 
+        // 온보딩 완료 여부는 서버 DB(users.profile_completed)를 단일 기준으로 삼는다.
+        boolean profileCompleted = userRepository.findProfileById(user.id())
+                .map(UserProfile::profileCompleted)
+                .orElse(false);
+
         return LoginResponse.of(
                 user.id(),
                 user.username(),
@@ -56,7 +62,8 @@ public class LoginService {
                 accessToken,
                 refreshToken,
                 jwtTokenService.accessTokenExpiryMs() / 1000,
-                jwtTokenService.refreshTokenExpiryMs() / 1000
+                jwtTokenService.refreshTokenExpiryMs() / 1000,
+                profileCompleted
         );
     }
 }

--- a/src/test/java/com/campost/backend/domain/auth/service/LoginServiceTest.java
+++ b/src/test/java/com/campost/backend/domain/auth/service/LoginServiceTest.java
@@ -50,6 +50,7 @@ class LoginServiceTest {
                 "USER",
                 OffsetDateTime.now()
         ));
+        userRepository.profileCompleted = true;
 
         LoginResponse response = loginService.login(new LoginRequest("campost123", "password123"));
 
@@ -63,6 +64,7 @@ class LoginServiceTest {
         assertThat(response.tokenType()).isEqualTo("Bearer");
         assertThat(response.expiresIn()).isEqualTo(ACCESS_TOKEN_EXPIRY_MS / 1000);
         assertThat(response.refreshTokenExpiresIn()).isEqualTo(REFRESH_TOKEN_EXPIRY_MS / 1000);
+        assertThat(response.profileCompleted()).isTrue();
         assertThat(accessClaims.getSubject()).isEqualTo("1");
         assertThat(accessClaims.get("role", String.class)).isEqualTo("USER");
         assertThat(accessClaims.get("tokenType", String.class)).isEqualTo(JwtTokenService.ACCESS_TOKEN_TYPE);
@@ -108,6 +110,7 @@ class LoginServiceTest {
     private static class FakeUserRepository implements UserRepository {
 
         private Optional<User> foundUser = Optional.empty();
+        private boolean profileCompleted = false;
 
         @Override
         public User save(SignupUserCreateCommand command) {
@@ -136,7 +139,18 @@ class LoginServiceTest {
 
         @Override
         public Optional<UserProfile> findProfileById(long userId) {
-            throw new UnsupportedOperationException("Not used in this test.");
+            return foundUser.map(user -> new UserProfile(
+                    user.id(),
+                    user.username(),
+                    user.email(),
+                    user.name(),
+                    null,
+                    null,
+                    user.role(),
+                    profileCompleted,
+                    user.createdAt(),
+                    null
+            ));
         }
 
         @Override


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #90

## 🏷️ PR 타입

- [ ] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)
- [ ] ⚙️ 프로젝트 초기 설정 (Chore)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🚨 PR 복구 (Revert)

## 📝 작업 내용

- `LoginResponse`에 `profileCompleted` 필드 추가
- `LoginService`에서 `users.profile_completed`(DB)를 조회해 응답에 포함
- `LoginServiceTest`에 profileCompleted 검증 추가

## 📎 기타 참고사항

- **원인**: 로그인 응답에 `profileCompleted`가 없어 프론트가 항상 localStorage 폴백에 의존 → localStorage가 비면 온보딩 완료 사용자에게도 온보딩 화면 재노출
- **해결**: 온보딩 완료 여부의 단일 기준을 서버 DB(`users.profile_completed`)로 통일. 프론트는 이미 `result.profileCompleted`를 우선 사용하므로 프론트 변경 불필요
- 로컬 검증: 테스트 72개 전부 통과(BUILD SUCCESS)